### PR TITLE
Sample / template projects

### DIFF
--- a/ae5_tools/cli/commands/project.py
+++ b/ae5_tools/cli/commands/project.py
@@ -34,6 +34,19 @@ def list(project, collaborators):
 
 
 @project.command()
+@click.argument('project', required=False)
+@format_options()
+@login_options()
+def samples(project):
+    '''List sample projects.
+    '''
+    result = cluster_call('project_samples', format='dataframe')
+    if project:
+        add_param('filter', Identifier.from_string(project).project_filter())
+    print_output(result)
+
+
+@project.command()
 @click.argument('project')
 @format_options()
 @login_options()
@@ -44,6 +57,19 @@ def info(project):
        wildcards. But it must match exactly one project.
     '''
     result = cluster_call('project_info', project, collaborators=True, format='dataframe')
+    print_output(result)
+
+
+@project.command()
+@click.argument('name_or_id')
+@format_options()
+@login_options()
+def sample_info(name_or_id):
+    '''Obtain information about a single sample project.
+
+       The NAME_OR_ID identifier may include wildcards but it must match exactly one sample.
+    '''
+    result = cluster_call('project_sample_info', name_or_id, format='dataframe')
     print_output(result)
 
 

--- a/ae5_tools/cli/main.py
+++ b/ae5_tools/cli/main.py
@@ -22,8 +22,8 @@ from .commands.job import job
 from .commands.run import run
 from .commands.user import user
 
-from .login import login_options, cluster
-from .format import format_options
+from .login import login_options, cluster, cluster_call
+from .format import format_options, print_output
 
 
 @click.group(invoke_without_command=True,
@@ -77,6 +77,19 @@ def logout(admin):
     if c is not None and c.connected:
         c.disconnect()
         click.echo('Logged out.', err=True)
+
+
+@cli.command()
+@click.argument('endpoint')
+@login_options()
+@format_options()
+def call(endpoint):
+    '''Make a generic API call. Useful for experimentation. There is no input validation
+       nor is there a guarantee that the output will be compatible with the generic
+       formatting logic. Currently support GET calls only.
+    '''
+    result = cluster_call('_api', 'get', endpoint, format='dataframe')
+    print_output(result)
 
 
 cli.add_command(project)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -34,12 +34,20 @@ def impersonate_session(admin_session):
 
 @pytest.fixture()
 def user_project_list(user_session):
-    return user_session.project_list(collaborators=True)
+    project_list = user_session.project_list(collaborators=True)
+    for r in project_list:
+        if r['name'] == 'test_upload':
+            user_session.project_delete(r['id'])    
+    return [r for r in project_list if r['name'] != 'test_upload']
 
 
 @pytest.fixture()
 def user_project_list_imp(impersonate_session):
-    return impersonate_session.project_list(collaborators=True)
+    project_list = impersonate_session.project_list(collaborators=True)
+    for r in project_list:
+        if r['name'] == 'test_upload':
+            impersonate_session.project_delete(r['id'])    
+    return [r for r in project_list if r['name'] != 'test_upload']
 
 
 @pytest.fixture()


### PR DESCRIPTION
Added `ae5 project samples` and `ae5 project sample-info`.

The API actually distinguishes between sample projects and template projects. But it does so in a non-intuitive way: the sample project list _excludes_ the template list, even though in the GUI, they are combined. Furthermore, the raw index information includes both, with a simple `is_template` flag to differentiate. So I've partially reconstructed this unified view here by making two API calls and merging the lists together with a constructed `is_template` flag.