### PR TITLE
Build Docker Image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ package-lock.json
 *.ipynb
 *.tar.gz
 .idea/
+
+# ides
+.vscode

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include versioneer.py
 include ae5_tools/_version.py
+include ae5_tools/Dockerfile.dist

--- a/ae5_tools/Dockerfile.dist
+++ b/ae5_tools/Dockerfile.dist
@@ -38,4 +38,4 @@ RUN tar xfz project.tar.gz --strip-components=1 && \
 
 # This runs the specified deployment command, which could (for
 # instance launch a REST API or web app.
-CMD ["anaconda-project", "run"]
+CMD anaconda-project run

--- a/ae5_tools/Dockerfile.dist
+++ b/ae5_tools/Dockerfile.dist
@@ -10,13 +10,15 @@ FROM centos
 ADD https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh miniconda.sh
 
 # Optional configuration of on-premises repository
-ARG CHANNEL_ALIAS=https://conda.anaconda.org/
+ARG CHANNEL_ALIAS="anaconda_cloud"
 
 RUN yum install -y bzip2 && \
     bash miniconda.sh -b -p /opt/conda && \
-    /opt/conda/bin/conda config --system --set channel_alias ${CHANNEL_ALIAS} && \
-    /opt/conda/bin/conda config --system --append default_channels ${CHANNEL_ALIAS}/anaconda && \
-    /opt/conda/bin/conda config --system --append default_channels ${CHANNEL_ALIAS}/r && \
+    if [ "${CHANNEL_ALIAS}" != "anaconda_cloud" ]; then \
+        /opt/conda/bin/conda config --system --set channel_alias ${CHANNEL_ALIAS} && \
+        /opt/conda/bin/conda config --system --append default_channels ${CHANNEL_ALIAS}/anaconda && \
+        /opt/conda/bin/conda config --system --append default_channels ${CHANNEL_ALIAS}/r; \
+    fi; \
     /opt/conda/bin/conda config --set auto_update_conda False --system && \
     /opt/conda/bin/conda install anaconda-project --yes && \
     /opt/conda/bin/conda clean --all --yes && \

--- a/ae5_tools/Dockerfile.dist
+++ b/ae5_tools/Dockerfile.dist
@@ -1,0 +1,41 @@
+# The base image is flexible; it simply needs to be able
+# to support Anaconda-built glibc binaries.
+FROM centos
+
+# Miniconda is a minimal Python environment, consisting only of Python
+# and the conda package manager. Instead of hosting it in the same directory
+# as this Dockerfile, it could be downloaded directly from repo.anaconda.com
+# using a curl command in the RUN statement below. The only additional package
+# we install in the environment is anaconda-project.
+ADD https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh miniconda.sh
+
+# Optional configuration of on-premises repository
+ARG CHANNEL_ALIAS=https://conda.anaconda.org/
+
+RUN yum install -y bzip2 && \
+    bash miniconda.sh -b -p /opt/conda && \
+    /opt/conda/bin/conda config --system --set channel_alias ${CHANNEL_ALIAS} && \
+    /opt/conda/bin/conda config --system --append default_channels ${CHANNEL_ALIAS}/anaconda && \
+    /opt/conda/bin/conda config --system --append default_channels ${CHANNEL_ALIAS}/r && \
+    /opt/conda/bin/conda config --set auto_update_conda False --system && \
+    /opt/conda/bin/conda install anaconda-project --yes && \
+    /opt/conda/bin/conda clean --all --yes && \
+    rm -f miniconda.sh && \
+    useradd anaconda
+
+
+USER anaconda
+WORKDIR /home/anaconda
+ENV PATH="/opt/conda/bin:${PATH}"
+RUN conda info
+COPY --chown=anaconda project.tar.gz .
+# The --strip-components option puts the project files directly
+# into the /home/anaconda directory. anaconda-project prepare
+# creates the conda environment for the project
+RUN tar xfz project.tar.gz --strip-components=1 && \
+    rm -f project.tar.gz && \
+    anaconda-project --verbose prepare
+
+# This runs the specified deployment command, which could (for
+# instance launch a REST API or web app.
+CMD ["anaconda-project", "run"]

--- a/ae5_tools/api.py
+++ b/ae5_tools/api.py
@@ -435,7 +435,7 @@ class AEUserSession(AESessionBase):
                 self.project_download(ident, filename=os.path.join(tempdir, 'project.tar.gz'))
             
             ae5_hostname = self.hostname if not use_anaconda_cloud else None
-            print('Starting image build. This may take several minutes...')
+            print('Starting image build. This may take several minutes.')
             image = build_image(tempdir, tag=tag, ae5_hostname=ae5_hostname, debug=debug)
             return image
 

--- a/ae5_tools/api.py
+++ b/ae5_tools/api.py
@@ -421,10 +421,10 @@ class AEUserSession(AESessionBase):
 
     def project_image(self, ident, command=None, use_anaconda_cloud=False, dockerfile_path=None, debug=False):
         '''Build docker image'''
-        id, rev, _, _ = self._revision(ident)
+        id, rev, _, rrec = self._revision(ident)
         info = self.project_info(ident, format='response')
         name = info['name'].replace(' ','').lower()
-        owner = info['owner']
+        owner = info['owner'].replace('@','_at_')
         tag = f'{owner}/{name}:{rev}'
 
         if dockerfile_path:
@@ -438,7 +438,23 @@ class AEUserSession(AESessionBase):
             dockerfile = get_dockerfile()
         
         if command:
-            dockerfile = re.sub('(CMD anaconda-project run)(.*?)$', f'\g<1> {command}', dockerfile)
+            commands = [c['id'] for c in rrec['commands']]
+            if not commands:
+                print('There are now configured commands in this project.')
+                print('Remove the --command option to build the container anyway.')
+                return
+            if command in commands:
+                dockerfile = re.sub('(CMD anaconda-project run)(.*?)$', f'\g<1> {command}', dockerfile)
+            else:
+                print(f'The command {command} is not one of the configured commands.')
+                print('Available commands are:')
+                for c in rrec['commands']:
+                    default = c.get('default', False)
+                    if default:
+                        print(f'  {c["id"]:15s} (default)')
+                    else:
+                        print(f'  {c["id"]:15s}')
+                return
 
         with TemporaryDirectory() as tempdir:
             with open(os.path.join(tempdir, 'Dockerfile'), 'w') as f:

--- a/ae5_tools/api.py
+++ b/ae5_tools/api.py
@@ -419,7 +419,7 @@ class AEUserSession(AESessionBase):
         with open(filename, 'wb') as fp:
             fp.write(response)
 
-    def project_image(self, ident, use_anaconda_cloud=False, debug=False):
+    def project_image(self, ident, use_anaconda_cloud=False, dockerfile_path=None, debug=False):
         '''Build docker image'''
         id, rev, _, _ = self._revision(ident)
         info = self.project_info(ident, format='response')
@@ -427,7 +427,15 @@ class AEUserSession(AESessionBase):
         owner = info['owner']
         tag = f'{owner}/{name}:{rev}'
 
-        dockerfile = get_dockerfile()
+        if dockerfile_path:
+            if not os.path.exists(dockerfile_path):
+                print(f'The requested Dockerfile was not found.\n{dockerfile_path}.')
+                return
+            else:
+                with open(dockerfile_path) as f:
+                    dockerfile = f.read()
+        else:
+            dockerfile = get_dockerfile()
 
         with TemporaryDirectory() as tempdir:
             with open(os.path.join(tempdir, 'Dockerfile'), 'w') as f:
@@ -436,8 +444,7 @@ class AEUserSession(AESessionBase):
             
             ae5_hostname = self.hostname if not use_anaconda_cloud else None
             print('Starting image build. This may take several minutes.')
-            image = build_image(tempdir, tag=tag, ae5_hostname=ae5_hostname, debug=debug)
-            return image
+            build_image(tempdir, tag=tag, ae5_hostname=ae5_hostname, debug=debug)
 
     def project_delete(self, ident):
         id, _ = self._id('projects', ident)

--- a/ae5_tools/api.py
+++ b/ae5_tools/api.py
@@ -419,7 +419,7 @@ class AEUserSession(AESessionBase):
         with open(filename, 'wb') as fp:
             fp.write(response)
 
-    def project_image(self, ident, use_anaconda_cloud=False, dockerfile_path=None, debug=False):
+    def project_image(self, ident, command=None, use_anaconda_cloud=False, dockerfile_path=None, debug=False):
         '''Build docker image'''
         id, rev, _, _ = self._revision(ident)
         info = self.project_info(ident, format='response')
@@ -436,6 +436,9 @@ class AEUserSession(AESessionBase):
                     dockerfile = f.read()
         else:
             dockerfile = get_dockerfile()
+        
+        if command:
+            dockerfile = re.sub('(CMD anaconda-project run)(.*?)$', f'\g<1> {command}', dockerfile)
 
         with TemporaryDirectory() as tempdir:
             with open(os.path.join(tempdir, 'Dockerfile'), 'w') as f:

--- a/ae5_tools/cli/commands/project.py
+++ b/ae5_tools/cli/commands/project.py
@@ -201,10 +201,11 @@ def download(ctx, project, filename):
 @project.command()
 @click.argument('project')
 @click.option('--use_anaconda_cloud', is_flag=True, help='Configure Docker image to pull packages from Anaconda Cloud rather than on-premises repository.')
+@click.option('--dockerfile', default='', help='Path to custom Dockerfile.')
 @click.option('--debug', is_flag=True, help='Show docker image build logs.')
 @login_options()
 @click.pass_context
-def image(ctx, project, use_anaconda_cloud, debug):
+def image(ctx, project, use_anaconda_cloud, dockerfile, debug):
     '''Build a Docker Image of a project.
 
        Using the template Dockerfile the project archive is downloaded and a runable
@@ -217,8 +218,8 @@ def image(ctx, project, use_anaconda_cloud, debug):
        If not supplied, the latest revision will be selected.
     '''
     from .revision import image as revision_image
-    ctx.invoke(revision_image, revision=project, use_anaconda_cloud=use_anaconda_cloud, debug=debug)
-
+    ctx.invoke(revision_image, revision=project, use_anaconda_cloud=use_anaconda_cloud, dockerfile=dockerfile, debug=debug)
+    
 
 @project.command()
 @click.argument('filename', type=click.Path(exists=True))

--- a/ae5_tools/cli/commands/project.py
+++ b/ae5_tools/cli/commands/project.py
@@ -6,7 +6,7 @@ from ..format import print_output, format_options
 from ...identifier import Identifier
 
 
-@click.group(short_help='list, info, download, upload, deploy, deployments, jobs, runs, activity, status, delete',
+@click.group(short_help='list, info, download, image, upload, deploy, deployments, jobs, runs, activity, status, delete',
              epilog='Type "ae5 project <command> --help" for help on a specific command.')
 @format_options()
 @login_options()
@@ -196,6 +196,28 @@ def download(ctx, project, filename):
     '''
     from .revision import download as revision_download
     ctx.invoke(revision_download, revision=project, filename=filename)
+
+
+@project.command()
+@click.argument('project')
+@click.option('--use_anaconda_cloud', is_flag=True, help='Configure Docker image to pull packages from Anaconda Cloud rather than on-premises repository.')
+@click.option('--debug', is_flag=True, help='Show docker image build logs.')
+@login_options()
+@click.pass_context
+def image(ctx, project, use_anaconda_cloud, debug):
+    '''Build a Docker Image of a project.
+
+       Using the template Dockerfile the project archive is downloaded and a runable
+       Docker image is built. The PROJECT identifier need not be fully specified,
+       and may even include wildcards. But it must match exactly one project.
+
+       By default the image will pull files from this AE5 Repository.
+
+       A revision value may optionally be supplied in the PROJECT identifier.
+       If not supplied, the latest revision will be selected.
+    '''
+    from .revision import image as revision_image
+    ctx.invoke(revision_image, revision=project, use_anaconda_cloud=use_anaconda_cloud, debug=debug)
 
 
 @project.command()

--- a/ae5_tools/cli/commands/project.py
+++ b/ae5_tools/cli/commands/project.py
@@ -198,7 +198,7 @@ def image(ctx, project, command, use_anaconda_cloud, dockerfile, debug):
        A revision value may optionally be supplied in the PROJECT identifier.
        If not supplied, the latest revision will be selected.
     '''
-    from .revision import image as revision_image
+    from .project_revision import image as revision_image
     ctx.invoke(revision_image, revision=project, command=command, use_anaconda_cloud=use_anaconda_cloud, dockerfile=dockerfile, debug=debug)
 
 

--- a/ae5_tools/cli/commands/project.py
+++ b/ae5_tools/cli/commands/project.py
@@ -200,12 +200,13 @@ def download(ctx, project, filename):
 
 @project.command()
 @click.argument('project')
+@click.option('--command', default='', help='Command name to execute.')
 @click.option('--use_anaconda_cloud', is_flag=True, help='Configure Docker image to pull packages from Anaconda Cloud rather than on-premises repository.')
 @click.option('--dockerfile', default='', help='Path to custom Dockerfile.')
 @click.option('--debug', is_flag=True, help='Show docker image build logs.')
 @login_options()
 @click.pass_context
-def image(ctx, project, use_anaconda_cloud, dockerfile, debug):
+def image(ctx, project, command, use_anaconda_cloud, dockerfile, debug):
     '''Build a Docker Image of a project.
 
        Using the template Dockerfile the project archive is downloaded and a runable
@@ -218,7 +219,7 @@ def image(ctx, project, use_anaconda_cloud, dockerfile, debug):
        If not supplied, the latest revision will be selected.
     '''
     from .revision import image as revision_image
-    ctx.invoke(revision_image, revision=project, use_anaconda_cloud=use_anaconda_cloud, dockerfile=dockerfile, debug=debug)
+    ctx.invoke(revision_image, revision=project, command=command, use_anaconda_cloud=use_anaconda_cloud, dockerfile=dockerfile, debug=debug)
     
 
 @project.command()

--- a/ae5_tools/cli/commands/revision.py
+++ b/ae5_tools/cli/commands/revision.py
@@ -61,5 +61,5 @@ def image(revision, use_anaconda_cloud, debug):
     _, pid, _, rev = record['url'].rsplit('/', 3)
     pid = 'a0-' + pid
 
-    image = cluster_call('project_image', f'{pid}:{rev}', use_anaconda_cloud, debug)
-    print(f'Docker Image {image} created.')
+    cluster_call('project_image', f'{pid}:{rev}', use_anaconda_cloud, debug)
+

--- a/ae5_tools/cli/commands/revision.py
+++ b/ae5_tools/cli/commands/revision.py
@@ -54,12 +54,13 @@ def download(revision, filename):
 @revision.command()
 @click.argument('revision')
 @click.option('--use_anaconda_cloud', is_flag=True, help='public repo')
+@click.option('--dockerfile', default='', help='dockerfile path')
 @click.option('--debug', is_flag=True, help='debug logs')
-def image(revision, use_anaconda_cloud, debug):
+def image(revision, use_anaconda_cloud, dockerfile, debug):
     ident = Identifier.from_string(revision)
     record = cluster_call('revision_info', ident, format='json')
     _, pid, _, rev = record['url'].rsplit('/', 3)
     pid = 'a0-' + pid
 
-    cluster_call('project_image', f'{pid}:{rev}', use_anaconda_cloud, debug)
+    cluster_call('project_image', f'{pid}:{rev}', use_anaconda_cloud, dockerfile_path=dockerfile, debug=debug)
 

--- a/ae5_tools/cli/commands/revision.py
+++ b/ae5_tools/cli/commands/revision.py
@@ -53,14 +53,15 @@ def download(revision, filename):
 
 @revision.command()
 @click.argument('revision')
+@click.option('--command', default='', help='Command name to execute.')
 @click.option('--use_anaconda_cloud', is_flag=True, help='public repo')
 @click.option('--dockerfile', default='', help='dockerfile path')
 @click.option('--debug', is_flag=True, help='debug logs')
-def image(revision, use_anaconda_cloud, dockerfile, debug):
+def image(revision, command, use_anaconda_cloud, dockerfile, debug):
     ident = Identifier.from_string(revision)
     record = cluster_call('revision_info', ident, format='json')
     _, pid, _, rev = record['url'].rsplit('/', 3)
     pid = 'a0-' + pid
 
-    cluster_call('project_image', f'{pid}:{rev}', use_anaconda_cloud, dockerfile_path=dockerfile, debug=debug)
+    cluster_call('project_image', f'{pid}:{rev}', command=command, use_anaconda_cloud=use_anaconda_cloud, dockerfile_path=dockerfile, debug=debug)
 

--- a/ae5_tools/cli/commands/revision.py
+++ b/ae5_tools/cli/commands/revision.py
@@ -5,7 +5,7 @@ from ..format import print_output, format_options
 from ...identifier import Identifier
 
 
-@click.group(short_help='list, info, download',
+@click.group(short_help='list, info, download, image',
              epilog='Type "ae5 revision <command> --help" for help on a specific command.')
 @format_options()
 @login_options()
@@ -49,3 +49,17 @@ def download(revision, filename):
         filename = f'{name}{revdash}.tar.gz'
     cluster_call('project_download', f'{pid}:{rev}', filename=filename)
     print(f'File {filename} downloaded.')
+
+
+@revision.command()
+@click.argument('revision')
+@click.option('--use_anaconda_cloud', is_flag=True, help='public repo')
+@click.option('--debug', is_flag=True, help='debug logs')
+def image(revision, use_anaconda_cloud, debug):
+    ident = Identifier.from_string(revision)
+    record = cluster_call('revision_info', ident, format='json')
+    _, pid, _, rev = record['url'].rsplit('/', 3)
+    pid = 'a0-' + pid
+
+    image = cluster_call('project_image', f'{pid}:{rev}', use_anaconda_cloud, debug)
+    print(f'Docker Image {image} created.')

--- a/ae5_tools/docker.py
+++ b/ae5_tools/docker.py
@@ -1,0 +1,81 @@
+'''Docker utilities'''
+
+import os
+import sys
+import json
+import logging
+from os import path
+
+
+def get_logger(name, stdout=False):
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.DEBUG)
+    filename = f'{name.replace(":","__").replace("/","-")}.log'
+    file_handler = logging.FileHandler(filename=filename)
+    logger.addHandler(file_handler)
+    if stdout:
+        stdout_handler = logging.StreamHandler(sys.stdout)
+        logger.addHandler(stdout_handler)
+    
+    return logger
+
+def get_dockerfile():
+    '''return path to dockerfile
+
+    The following locations are scanned in order
+    for the Dockerfile
+    1. ~/.ae5/Dockerfile
+    2. <site-packages>/ae5_tools/Dockerfile.dist
+    '''
+
+    _path = path.expanduser(os.getenv('AE5_TOOLS_CONFIG_DIR') or '~/.ae5')
+    user_file = path.join(_path, 'Dockerfile')
+    dist_file = path.join(path.dirname(__file__), 'Dockerfile.dist')
+    if path.exists(user_file):
+        dockerfile = user_file
+    elif path.exists(dist_file):
+        dockerfile = dist_file
+    else:
+        msg = f'''Dockerfile was not found in any of the following locations
+{user_file}
+{dist_file}
+Please check that the file exists or that ae5-tools was installed properly.
+Otherwise, please file a bug report.'''
+        raise FileNotFoundError(msg)
+
+    with open(dockerfile) as f:
+        contents = f.read()
+    return contents
+
+
+def build_image(path, tag, ae5_hostname=None, debug=False):
+    try:
+        import docker
+    except ModuleNotFoundError as e:
+        print('You must install docker-py to build an image')
+        raise(e)
+    
+    client = docker.from_env()
+
+    buildargs={'CHANNEL_ALIAS':f'https://{ae5_hostname}/repository/conda/'} if ae5_hostname else None
+    logger = get_logger(tag, stdout=debug)
+    print(f'Build logs written to {logger.handlers[0].baseFilename}')
+    try:
+        logger.debug(f'*** {tag} image build starting')
+        for line in client.api.build(path=path, tag=tag, buildargs=buildargs):
+            text = line.decode().strip()
+            logger.info(text)
+            try:
+                d = json.loads(text)
+                error = d.get('error', False)
+                if error:
+                    raise docker.errors.BuildError(d['error'], line)
+            except json.decoder.JSONDecodeError:
+                pass
+
+
+    except docker.errors.BuildError as e:
+        print('An error was encountered while building the image.')
+        print(e)
+    
+    return tag

--- a/ae5_tools/docker.py
+++ b/ae5_tools/docker.py
@@ -16,7 +16,7 @@ def get_logger(name, stdout=False):
     if stdout:
         stdout_handler = logging.StreamHandler(sys.stdout)
         logger.addHandler(stdout_handler)
-    
+
     return logger
 
 
@@ -52,9 +52,13 @@ Otherwise, please file a bug report.'''
 def build_image(path, tag, ae5_hostname=None, debug=False):
     try:
         import docker
-    except ModuleNotFoundError as e:
+    except ModuleNotFoundError:
+        print()
         print('You must install docker-py to build an image')
-        raise(e)
+        print()
+        print('  conda install -c conda-forge docker-py')
+        print()
+        return
 
     logger = get_logger(tag, stdout=debug)
     print(f'Build logs written to {logger.handlers[0].baseFilename}')

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,12 @@
+name: ae5-tools
+dependencies:
+  - python=3.7
+  - requests
+  - pandas
+  - click
+  - click-repl
+  - lxml
+  - docker-py
+channels:
+  - defaults
+  - conda-forge


### PR DESCRIPTION
This PR adds `project image` command, which will automatically prepare and build a Docker image from a project (revision optional). Here are the steps that it performs.

1. create temporary directory
1. download chosen project revision as `project.tar.gz` into temporary directory
1. copy Dockerfile (see next section for location of templates)
1. build docker image using [docker/docker-py](https://github.com/docker/docker-py)
   * the image is tagged as `$OWNER/$PROJECT_NAME:$TAG`.
   * `$PROJECT_NAME` is the name of project in lower-case with spaces removed
   * `$TAG` is the commit tag of the chosen revision
   * See [docker-py docs](https://docker-py.readthedocs.io/en/stable/client.html) for env vars to connect to docker host
1. remove temporary directory

See example usage below.

## Dockerfile

This package installs `<site-packages>/ae5_tools/Dockerfile.dist` ([source](https://github.com/AlbertDeFusco/ae5-tools/blob/docker/ae5_tools/Dockerfile.dist)), which is used by default to build the image.

This Dockerfile does not implement the `--anaconda-project-X` arguments. This means that commands need not be served over port 8086, nor can that be guaranteed. 

By default no command name is provided and it is likely that the first command is run. Use `--command` to run a specific command by name. This will perform the following regex.

```
dockerfile = re.sub('(CMD anaconda-project run)(.*?)$', f'\g<1> {command}', dockerfile)
```

A custom Dockerfile can be utilized used by 
1. passing `--dockerfile=/path/to/Dockerfile` argument. (highest priority)
1. creating `~/.ae5/Dockerfile`. 

Custom Dockerfiles are expected to handle `CHANNEL_ALIAS` as a buildarg.


## Conda Repository

By default the image is built using the on-premises repository channel_alias. Add the `--use_anaconda_cloud` option to set the channel_alias to https://conda.anaconda.org.

The following configurations are made (see Dockerfile.dist) by setting `CHANNEL_ALIAS` as a docker build arg. 

```
ARG CHANNEL_ALIAS="anaconda_cloud"
RUN    if [ "${CHANNEL_ALIAS}" != "anaconda_cloud" ]; then \
        /opt/conda/bin/conda config --system --set channel_alias ${CHANNEL_ALIAS} && \
        /opt/conda/bin/conda config --system --append default_channels ${CHANNEL_ALIAS}/anaconda && \
        /opt/conda/bin/conda config --system --append default_channels ${CHANNEL_ALIAS}/r; \
    fi; \
```

It was found that setting only `channel_alias` would not stop conda from searching repo.anaconda.com/pkgs so `default_channels` needed to be added.

## Example

Step 1 build image from project.

```
(ae5-tools-dev) adefusco@0235-adefusco:~>ae5 --hostname <hostname> --username <username> --password <password>
Anaconda Enterprise 5 REPL
Type "--help" for a list of commands.
Type "<command> --help" for help on a specific command.

> project list a0-2db5453ebc644747aab8a9694a799142                                                                                                           
Connected as <username>@<hostname>
name             owner    editor      resource_profile  id                                   created                           updated
---------------  -------  ----------  ----------------  -----------------------------------  --------------------------------  ------------------------------
data_clustering  smunroe  jupyterlab  default           a0-2db5453ebc644747aab8a9694a799142  2019-02-19 22:10:05.937399+00:00  2019-02-19 22:11:15.656258+...

> project image a0-2db5453ebc644747aab8a9694a799142 --use_anaconda_cloud                                                                                     
Starting image build. This may take several minutes.
Build logs written to /Users/adefusco/smunroe-data_clustering__0.1.0.log
Docker Image smunroe/data_clustering:0.1.0 created.
>
```

Verify and run the image.

```
(ae5-tools-dev) adefusco@0235-adefusco:~>docker image ls
REPOSITORY                       TAG                 IMAGE ID            CREATED             SIZE
smunroe/data_clustering          0.1.0               c063edca35a4        3 minutes ago       2.15GB
centos                           latest              9f38484d220f        3 months ago        202MB
certbot/dns-route53              latest              957b164951b2        5 months ago        146MB

(ae5-tools-dev) adefusco@0235-adefusco:~>docker run -p 5006:5006 smunroe/data_clustering:0.1.0
2019-07-07 19:31:50,985 Starting Bokeh server version 0.12.5
2019-07-07 19:31:50,988 Starting Bokeh server on port 5006 with applications at paths ['/anaconda']
2019-07-07 19:31:50,989 Starting Bokeh server with process id: 1
2019-07-07 19:31:57,694 200 GET /anaconda (172.17.0.1) 440.20ms
2019-07-07 19:31:57,915 101 GET /anaconda/ws?bokeh-protocol-version=1.0&bokeh-session-id=eCs35DekAio86MFSvWwE1j4kh8MkfB1FQmUUNc0C4bIZ (172.17.0.1) 0.62ms
2019-07-07 19:31:57,915 WebSocket connection opened
2019-07-07 19:31:57,916 ServerConnection created
```