### PR TITLE
Fix deployment requests

### DIFF
--- a/ae5_tools/api.py
+++ b/ae5_tools/api.py
@@ -9,11 +9,6 @@ from lxml import html
 from os.path import basename
 from fnmatch import fnmatch
 import getpass
-<<<<<<< Updated upstream
-=======
-
-from tempfile import TemporaryDirectory
->>>>>>> Stashed changes
 
 from .config import config
 from .identifier import Identifier

--- a/ae5_tools/api.py
+++ b/ae5_tools/api.py
@@ -9,6 +9,11 @@ from lxml import html
 from os.path import basename
 from fnmatch import fnmatch
 import getpass
+<<<<<<< Updated upstream
+=======
+
+from tempfile import TemporaryDirectory
+>>>>>>> Stashed changes
 
 from .config import config
 from .identifier import Identifier
@@ -227,7 +232,7 @@ class AEUserSession(AESessionBase):
     def _load(self):
         s = self.session
         if os.path.exists(self._filename):
-            s.cookies.load(self._filename)
+            s.cookies.load(self._filename, ignore_discard=True)
             os.utime(self._filename)
             try:
                 self._get('runs', format='response')
@@ -256,7 +261,7 @@ class AEUserSession(AESessionBase):
 
     def _save(self):
         os.makedirs(os.path.dirname(self._filename), mode=0o700, exist_ok=True)
-        self.session.cookies.save(self._filename)
+        self.session.cookies.save(self._filename, ignore_discard=True)
         os.chmod(self._filename, 0o600)
 
     def _id(self, type, ident, quiet=False):


### PR DESCRIPTION
By default cookies flagged as `discard` are not saved or loaded. This makes sure to save those cookies to disk. This helps make sure that we can use the session object to make requests to deployment urls.