### PR TITLE
Fix ae5 session info, etc

### DIFF
--- a/ae5_tools/api.py
+++ b/ae5_tools/api.py
@@ -535,8 +535,9 @@ class AEUserSession(AESessionBase):
 
     def session_list(self, internal=False, format=None):
         response = self._get('sessions', format='json')
-        if not internal:
-            self._join_projects(response, 'session')
+        # We need _join_projects even in internal mode to replace
+        # the internal session name with the project name
+        self._join_projects(response, 'session')
         return self._format_response(response, format, _S_COLUMNS)
 
     def session_info(self, ident, format=None, quiet=False):

--- a/ae5_tools/cli/commands/endpoint.py
+++ b/ae5_tools/cli/commands/endpoint.py
@@ -5,7 +5,7 @@ from ..login import login_options, cluster_call
 from ..format import print_output, format_options
 
 
-@click.group(short_help='Subcommands: info, list',
+@click.group(short_help='info, list',
              epilog='Type "ae5 endpoint <command> --help" for help on a specific command.')
 @format_options()
 @login_options()

--- a/ae5_tools/cli/commands/project_revision.py
+++ b/ae5_tools/cli/commands/project_revision.py
@@ -16,6 +16,7 @@ def revision():
 @revision.command()
 @click.argument('project')
 @format_options()
+@login_options()
 def list(project):
     '''List available revisions for a given project.
 
@@ -29,6 +30,7 @@ def list(project):
 @revision.command()
 @click.argument('revision')
 @format_options()
+@login_options()
 def info(revision):
     '''Get information about a single project revision.
 
@@ -43,6 +45,7 @@ def info(revision):
 @revision.command()
 @click.argument('revision')
 @click.option('--filename', default='', help='Filename')
+@login_options()
 def download(revision, filename):
     '''Download a project revision.
 

--- a/ae5_tools/cli/commands/session.py
+++ b/ae5_tools/cli/commands/session.py
@@ -110,7 +110,7 @@ def stop(session, yes):
        wildcards. But it must match exactly one session.
     '''
     result = single_session(session)
-    ident = f'{result["owner"]}/{result["name"]}/{result["id"]}'
+    ident = Identifier.from_record(result)
     if not yes:
         yes = click.confirm(f'Stop session {ident}', err=True)
     if yes:


### PR DESCRIPTION
Fixes uses of `ae5 session info` and related single-session commands where we search by name. Session records are the one thing we always modify before returning to the user, because the `name` field is not the human-readable name.