### PR TITLE
Persist multiple logins, enforce logout in REPL, add no-saved-logins

### DIFF
--- a/ae5_tools/cli/format.py
+++ b/ae5_tools/cli/format.py
@@ -18,9 +18,15 @@ def print_format_help(ctx, param, value):
     click_text('''
 @Formatting the tabular output: options
 
-Most of the CLI commands provide output in tabular form. By default, the tables
+Many AE5 commands provide output in JSON tabular form---either a single
+dictionary or a list of dictionaries with identical keys. By default, the tables
 are rendered in text suitable for viewing in a terminal. The output can be modified
-in a variety of ways with the following options.
+in a variety of ways with the following options. Non-tabular output is always
+returned in plain text form.
+
+In REPL mode, formatting options supplied on the command line serve as the default
+values for all commands executed in that session, but can be overridden on a
+per-command basis.
 
 @Options:
 ''')
@@ -206,6 +212,9 @@ def print_df(df, header=True, width=0):
 
 
 def print_output(result):
+    if isinstance(result, str):
+        print(result)
+        return
     opts = get_options()
     is_single = isinstance(result, pd.Series)
     if is_single:

--- a/ae5_tools/cli/login.py
+++ b/ae5_tools/cli/login.py
@@ -9,16 +9,25 @@ def print_login_help(ctx, param, value):
     if not value or ctx.resilient_parsing:
         return
     click_text('''
-@Logging into the AE5 cluster: options
+@Logging into the AE5 cluster
+----------------------------
 
 The CLI provides a number of options that can be used with most commands
-to control the authenticatio to the cluster. These options can be supplied
-using standard command-line options, or by setting environment variables
-whose names are given in parentheses below.
+to control authentication to the cluster. They can be supplied on the command
+line or by setting environment variables given in parentheses below.
 
-For convenience, the CLI tool will re-use the last hostname and username
-provided, unless overridden by these options. It will not request a password
-if the previous session has not yet expired.
+Login sessions are saved to disk unless --no-saved-logins
+option is supplied. This enables multiple AE5 calls to be made
+without re-entering a password. Passwords are *not* saved to disk, just
+the session and authentication cookies generated from it. The cookie
+file is saved with secure permissions, and is subject to expiration
+timeouts identical to interactive web sessions.
+
+If the hostname option is not supplied, then the hostname of the last saved
+session is used, even if its cookies are expired. If no saved session exists,
+the user will be prompted for a hostname. Similarly, default values of the
+username or admin username will be determined from the last saved sessions
+on the given hostname.
 
 @Options:
 ''')
@@ -32,18 +41,16 @@ if the previous session has not yet expired.
 
 _login_help = {
     'hostname': 'Hostname of the cluster. (AE5_HOSTNAME)',
-    'username': 'Username for user-level authentication. (AE5_USERNAME)',
-    'password': 'Password for user-level authentication. (AE5_PASSWORD)',
-    'admin-username': 'Keycloak admin username. (AE5_ADMIN_USERNAME)',
-    'admin-password': 'Keycloak admin password. (AE5_ADMIN_PASSWORD)',
-    'impersonate': ('If selected, uses impersonation to log in as the given user. '
-                    'This relies on the Keycloack admin credentials instead of '
-                    'requiring a user password. By default, standard user '
-                    'authentication is employed. (AE5_IMPERSONATE)'),
-    'no-saved-logins': ('By default, login sessions are saved to disk so they '
-                        'can be used across separate calls. If this flag is set, the '
-                        'sessions are neither loaded from disk or saved to disk, and '
-                        'must be supplied separately to each call of the tool. '
+    'username': 'Username for standard access. (AE5_USERNAME)',
+    'password': 'Password for standard access. (AE5_PASSWORD)',
+    'admin-username': 'Username for Keycloak admin access. (AE5_ADMIN_USERNAME)',
+    'admin-password': 'Password for Keycloak admin access. (AE5_ADMIN_PASSWORD)',
+    'impersonate': ('Use the Keycloak administrator account to impersonate the '
+                    'given user instead of requiring the user password. '
+                    '(AE5_IMPERSONATE)'),
+    'no-saved-logins': ('Do not load or save login sessions to/from disk. A password '
+                        'must be supplied, and its session will persist only for the '
+                        'duration of AE5 call, including multiple commands in REPL mode. '
                         '(AE5_NO_SAVED_LOGINS)')
 }
 

--- a/ae5_tools/cli/main.py
+++ b/ae5_tools/cli/main.py
@@ -23,7 +23,7 @@ from .commands.job import job
 from .commands.run import run
 from .commands.user import user
 
-from .login import login_options, cluster, cluster_call
+from .login import login_options, cluster, cluster_call, cluster_disconnect
 from .format import format_options, print_output
 from ..api import AEUsageError
 
@@ -64,8 +64,7 @@ def login(admin):
        initiate a login if necessary. Furthermore, if an active session already
        exists for the given hostname/username/password, this will do nothing.
     '''
-    cluster(admin=admin)
-
+    cluster_disconnect(admin=admin)
 
 @cli.command()
 @click.option('--admin', is_flag=True, help='Perform a KeyCloak admin login instead of a user login.')
@@ -76,10 +75,7 @@ def logout(admin):
        Sessions automatically time out, but this allows an existing session to
        be closed out to prevent accidental further use.
     '''
-    c = cluster(admin=admin, retry=False)
-    if c is not None and c.connected:
-        c.disconnect()
-        click.echo('Logged out.', err=True)
+    cluster_disconnect(admin)
 
 
 @cli.command()

--- a/ae5_tools/cli/main.py
+++ b/ae5_tools/cli/main.py
@@ -77,15 +77,33 @@ def logout(admin):
 
 
 @cli.command()
-@click.argument('endpoint')
+@click.argument('path')
 @login_options()
 @format_options()
-def call(endpoint):
-    '''Make a generic API call. Useful for experimentation. There is no input validation
-       nor is there a guarantee that the output will be compatible with the generic
-       formatting logic. Currently support GET calls only.
+def call(path):
+    '''Make a generic API call. This is useful for experimentation with the
+       AE5 API. However, it is particularly useful for accessing REST APIs
+       delivered as private deployments, because it handles authentication.
+       
+       The PATH argument looks like a standard URL path, without hostname or
+       scheme. However, if the path does not begin with a slash '/', this
+       component is assumed to be the subdomain for the deployment.
+
+       For instance, if the hostname is anaconda.test.com,
+          /api/v2/runs -> https://anaconda.test.com/api/v2/runs
+          deployment1  -> https://deployment1.anaconda.test.com/
+          deployment2/test/me -> https://deployment2.anaconda.test.com/test/me
+       
+       There is no input validation, nor is there a guarantee that the output will
+       be compatible with the generic formatting logic.
     '''
-    result = cluster_call('_api', 'get', endpoint, format='dataframe')
+    if path.startswith('/'):
+        subdomain = None
+    elif '/' in path:
+        subdomain, path = path.split('/', 1)
+    else:
+        subdomain, path = path, ''
+    result = cluster_call('_api', 'get', '/' + path.lstrip('/'), format='dataframe', subdomain=subdomain)
     print_output(result)
 
 

--- a/ae5_tools/cli/main.py
+++ b/ae5_tools/cli/main.py
@@ -25,6 +25,7 @@ from .commands.user import user
 
 from .login import login_options, cluster, cluster_call, cluster_disconnect
 from .format import format_options, print_output
+from .utils import stash_defaults
 from ..api import AEUsageError
 
 
@@ -35,8 +36,6 @@ from ..api import AEUsageError
 @click.pass_context
 def cli(ctx):
     obj = ctx.ensure_object(dict)
-    obj['is_interactive'] = sys.__stdin__.isatty()
-    obj['is_console'] = sys.__stdout__.isatty()
     if ctx.invoked_subcommand is None:
         ctx.invoke(repl)
 
@@ -46,8 +45,7 @@ def cli(ctx):
 @format_options()
 @click.pass_context
 def repl(ctx):
-    obj = ctx.ensure_object(dict)
-    obj['in_repl'] = True
+    stash_defaults()
     click.echo('Anaconda Enterprise 5 REPL')
     click.echo('Type "--help" for a list of commands.')
     click.echo('Type "<command> --help" for help on a specific command.')

--- a/ae5_tools/cli/utils.py
+++ b/ae5_tools/cli/utils.py
@@ -35,8 +35,9 @@ def get_options():
 def persist_option(param, value):
     ctx = click.get_current_context()
     obj = ctx.ensure_object(dict)
-    obj['defaults'][param] = obj['options'][param] = value
-
+    obj.setdefault('options', {})[param] = value
+    if 'defaults' in obj:
+        obj['defaults'][param] = value
 
 def param_callback(ctx, param, value):
     if value in (None, ()):


### PR DESCRIPTION
`ae5 logout` did not work as well in REPL mode. This has been rectified; no you can do, e.g.
```
ae5
> project list
> logout
> project list
> logout
> project list
```
Added a `--no-save-logins` option which skips loading and/or saving session info from disk, and automatically logs out of open sessions on exit.