### PR TITLE
Fix deployment restarts

### DIFF
--- a/ae5_tools/api.py
+++ b/ae5_tools/api.py
@@ -688,6 +688,8 @@ class AEUserSession(AESessionBase):
         collab = self.deployment_collaborators(id, format='json')
         if record.get('url'):
             endpoint = record['url'].split('/', 3)[2].split('.', 1)[0]
+            if id.endswith(endpoint):
+                endpoint = None
         else:
             endpoint = None
         self._delete(f'deployments/{id}', format='response')

--- a/ae5_tools/cli/commands/deployment.py
+++ b/ae5_tools/cli/commands/deployment.py
@@ -3,7 +3,7 @@ import webbrowser
 import re
 
 from ..login import cluster_call, login_options
-from ..utils import add_param
+from ..utils import add_param, get_options
 from ..format import print_output, format_options
 from ...identifier import Identifier
 from .deployment_collaborator import collaborator
@@ -182,9 +182,10 @@ def restart(ctx, deployment, wait, open, frame):
     '''
     drec = cluster_call('deployment_info', deployment, format='json')
     ident = Identifier.from_record(drec)
-    obj = ctx.ensure_object(dict)
-    if drec['owner'] != obj['username']:
-        raise click.ClickException(f'user {obj["username"]} cannot restart deployment {ident}')
+    opts = get_options()
+    username = opts['username']
+    if drec['owner'] != username:
+        raise click.ClickException(f'user {username} cannot restart deployment {ident}')
     click.echo(f'Restarting deployment {ident}...', nl=False, err=True)
     response = cluster_call('deployment_restart', drec['id'], wait=wait or open, format='dataframe')
     click.echo('restarted.', err=True)

--- a/ae5_tools/cli/main.py
+++ b/ae5_tools/cli/main.py
@@ -25,7 +25,7 @@ from .commands.user import user
 
 from .login import login_options, cluster, cluster_call, cluster_disconnect
 from .format import format_options, print_output
-from .utils import stash_defaults
+from .utils import stash_defaults, get_options
 from ..api import AEUsageError
 
 
@@ -62,7 +62,7 @@ def login(admin):
        initiate a login if necessary. Furthermore, if an active session already
        exists for the given hostname/username/password, this will do nothing.
     '''
-    cluster_disconnect(admin=admin)
+    cluster(admin)
 
 @cli.command()
 @click.option('--admin', is_flag=True, help='Perform a KeyCloak admin login instead of a user login.')
@@ -95,7 +95,8 @@ def call(path):
           deployment2/test/me -> https://deployment2.anaconda.test.com/test/me
        
        There is no input validation, nor is there a guarantee that the output will
-       be compatible with the generic formatting logic.
+       be compatible with the generic formatting logic. Only GET calls are currently
+       supported.
     '''
     if path.startswith('/'):
         subdomain = None
@@ -103,7 +104,8 @@ def call(path):
         subdomain, path = path.split('/', 1)
     else:
         subdomain, path = path, ''
-    result = cluster_call('_api', 'get', '/' + path.lstrip('/'), format='dataframe', subdomain=subdomain)
+    format = get_options().get('format')
+    result = cluster_call('_api', 'get', '/' + path.lstrip('/'), format=format, subdomain=subdomain)
     print_output(result)
 
 


### PR DESCRIPTION
Deployment restart was broken for a couple of reasons. Converting the `_id` function to use the internal record instead of the user-massaged record eliminated its access to the `endpoint` value. And the endpoint listing itself was breaking because of content-type issues