### PR TITLE
Ensure Python 3.6 compatibility, eliminate Pandas properly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 - conda install conda conda-build conda-verify anaconda-client --yes
 - conda info -a
 script:
-- conda build conda-recipe
+- conda build conda-recipe --python 3.6
 deploy:
 - provider: script
   skip_cleanup: true

--- a/ae5_tools/api.py
+++ b/ae5_tools/api.py
@@ -9,6 +9,7 @@ from lxml import html
 from os.path import basename
 from fnmatch import fnmatch
 from datetime import datetime
+from dateutil import parser
 import getpass
 
 from .config import config
@@ -174,7 +175,7 @@ class AESessionBase(object):
                 if dtype == 'datetime':
                     for rec in response:
                         if col in rec:
-                            rec[col] = datetime.fromisoformat(rec[col])
+                            rec[col] = parser.isoparse(rec[col])
                 elif dtype.startswith('timestamp'):
                     incr = dtype.rsplit('/', 1)[1]
                     fact = 1000.0 if incr == 'ms' else 1.0

--- a/ae5_tools/api.py
+++ b/ae5_tools/api.py
@@ -5,7 +5,6 @@ import re
 import os
 import sys
 import json
-import pandas as pd
 from lxml import html
 from os.path import basename
 from fnmatch import fnmatch

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - setuptools
   run:
     - python>=3.6
+    - python-dateutil
     - requests
     - click>=7
     - click-repl
@@ -30,6 +31,7 @@ test:
   source_files:
     - tests
   requires:
+    - python=3.6
     - pytest
     - pytest-cov
     - codecov

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -35,7 +35,6 @@ test:
     - pytest
     - pytest-cov
     - codecov
-    - pandas
   commands:
     - py.test --cov=ae5_tools -v tests
     - codecov -t $CODECOV_TOKEN


### PR DESCRIPTION
Fixes #48, #50
- Remove a `pandas` import that is no longer needed
- Add `python-dateutil` as a dependency (likely pulled in implicitly by pandas before)
- use `dateutil.parser.isoparse` instead of `datetime.fromisoformat`