### PR TITLE
Add support for deployment token generation and deployment log access

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The package has the following particular dependencies:
 
 - Composite commands:
     - `account`: `list`
-    - `deployment`: `info`, `list`, `open`, `patch`, `restart`, `start`, `stop`
+    - `deployment`: `info`, `list`, `logs`, `open`, `patch`, `restart`, `start`, `stop`, `token`
       - `collaborator`: `list`, `info`, `add`, `remove`
     - `editor`: `info`, `list`
     - `endpoint`: `info`, `list`

--- a/ae5_tools/api.py
+++ b/ae5_tools/api.py
@@ -189,7 +189,7 @@ class AESessionBase(object):
             result = [tuple(rec.get(k) for k in clist) for rec in response]
         return (result, clist)
 
-    def _format_response(self, response, format, columns):
+    def _format_response(self, response, format, columns=None):
         if isinstance(response, requests.models.Response):
             if format == 'response':
                 return response
@@ -273,6 +273,7 @@ class AESessionBase(object):
                     do_save = True
                     redirects = 0
                 url = url2
+                method = 'get'
             elif response.status_code == 401 or self._is_login(response):
                 self.authorize()
                 redirects = 0
@@ -871,6 +872,20 @@ class AEUserSession(AESessionBase):
     def deployment_stop(self, ident, format=None):
         id, _ = self._id('deployments', ident)
         return self._delete(f'deployments/{id}', format=format)
+
+    def deployment_logs(self, ident, which=None, format=None):
+        id, _ = self._id('deployments', ident)
+        result = self._get(f'deployments/{id}/logs', format='json')
+        if which is not None:
+            result = result[which]
+        return self._format_response(result, format=format)
+
+    def deployment_token(self, ident, which=None, format=None):
+        id, _ = self._id('deployments', ident)
+        result = self._post(f'deployments/{id}/token', format='json')
+        if isinstance(result, dict) and set(result) == {'token'}:
+            result = result['token']
+        return self._format_response(result, format=format)
 
     def job_list(self, internal=False, format=None):
         return self._get('jobs', format=format, columns=_J_COLUMNS)

--- a/ae5_tools/cli/commands/deployment.py
+++ b/ae5_tools/cli/commands/deployment.py
@@ -51,6 +51,37 @@ def info(deployment):
 
 @deployment.command()
 @click.argument('deployment')
+@click.option('--proxy', is_flag=True, help='Return the proxy log instead of the app log.')
+@click.option('--events', is_flag=True, help='Return the event log instead of the app log.')
+@format_options()
+@login_options()
+def logs(deployment, proxy, events):
+    '''Retrieve the logs for a deployment.
+
+       The DEPLOYMENT identifier need not be fully specified, and may even include
+       wildcards. But it must match exactly one project.
+    '''
+    if proxy and events:
+        raise click.ClickException('Cannot specify both --proxy and --events')
+    which = 'proxy' if proxy else ('events' if events else 'app')
+    cluster_call('deployment_logs', deployment, which=which, cli=True)
+
+
+@deployment.command()
+@click.argument('deployment')
+@format_options()
+@login_options()
+def token(deployment):
+    '''Retrieve a bearer token to access a private deployment.
+
+       The DEPLOYMENT identifier need not be fully specified, and may even include
+       wildcards. But it must match exactly one project.
+    '''
+    cluster_call('deployment_token', deployment, cli=True)
+
+
+@deployment.command()
+@click.argument('deployment')
 @click.option('--public', is_flag=True, help='Make the deployment public.')
 @click.option('--private', is_flag=True, help='Make the deployment private.')
 @format_options()

--- a/ae5_tools/cli/format.py
+++ b/ae5_tools/cli/format.py
@@ -224,7 +224,12 @@ def print_table(records, columns, header=True, width=0):
                 pass
         else:
             width = 80
+    if not records and not columns:
+        if header:
+            print('-' * width)
+        return
     nwidth = -2
+    head, dash, final = '', '', []
     for ndx, col in enumerate(columns):
         col = str(col)
         val = [_str(rec[ndx]) for rec in records]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ from .utils import _get_vars, _cmd
 # Furthermore, there should be a second user satisfying the following:
 # - At least one project shared with this user as a collaborator
 # - At least two of those projects are called testproj1, testproj2, or testproj3
-@pytest.fixture
+@pytest.fixture(scope='session')
 def user_setup():
     hostname, username, password = _get_vars('AE5_HOSTNAME', 'AE5_USERNAME', 'AE5_PASSWORD')
     s = AEUserSession(hostname, username, password)
@@ -44,7 +44,7 @@ def user_setup():
     s.disconnect()
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def admin_session():
     hostname, username, password = _get_vars('AE5_HOSTNAME', 'AE5_ADMIN_USERNAME', 'AE5_ADMIN_PASSWORD')
     s = AEAdminSession(hostname, username, password)
@@ -52,22 +52,22 @@ def admin_session():
     s.disconnect()
 
 
-@pytest.fixture()
+@pytest.fixture(scope='session')
 def user_session(user_setup):
     return user_setup[0]
 
 
-@pytest.fixture()
+@pytest.fixture(scope='session')
 def project_list(user_setup):
     return user_setup[1]
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def project_list_cli(user_session):
     return _cmd('project list --collaborators')
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def project_dup_names(project_list_cli):
     counts = {}
     for p in project_list_cli:


### PR DESCRIPTION
Weekend project, just filling out the API coverage for deployments. It's useful stuff: the ability to generate bearer tokens to allow non-authenticated users to access deployments; and the ability to retrieve the logs for a deployment.

Refactored the tests for deployments by wrapping the actual launching and stopping of the test deployment in a fixture. This allows me to build multiple smaller tests that manipulate the same deployment.