### PR TITLE
Adds --stop-on-error option

### DIFF
--- a/ae5_tools/cli/commands/deployment.py
+++ b/ae5_tools/cli/commands/deployment.py
@@ -119,12 +119,13 @@ def _open(record, frame):
 @click.option('--public', is_flag=True, help='Make the deployment public.')
 @click.option('--private', is_flag=True, help='Make the deployment private (the default).')
 @click.option('--wait', is_flag=True, help='Wait for the deployment to complete initialization before exiting.')
+@click.option('--stop-on-error', is_flag=True, help='Stop the deployment if it fails on the first attempt. Implies --wait.')
 @click.option('--open', is_flag=True, help='Open a browser upon initialization. Implies --wait.')
 @click.option('--frame', is_flag=True, help='Include the AE banner when opening.')
 @format_options()
 @login_options()
 @click.pass_context
-def start(ctx, project, name, endpoint, command, resource_profile, public, private, wait, open, frame):
+def start(ctx, project, name, endpoint, command, resource_profile, public, private, wait, stop_on_error, open, frame):
     '''Start a deployment for a project.
 
        The PROJECT identifier need not be fully specified, and may even include
@@ -161,7 +162,7 @@ def start(ctx, project, name, endpoint, command, resource_profile, public, priva
                             name=name if name else None,
                             endpoint=endpoint, command=command,
                             resource_profile=resource_profile, public=public,
-                            wait=wait or open,
+                            wait=wait or open, stop_on_error=stop_on_error,
                             prefix=f'Starting deployment{name_s}{endpoint_s} for {{ident}}...',
                             postfix='started.')
     if open:
@@ -171,19 +172,20 @@ def start(ctx, project, name, endpoint, command, resource_profile, public, priva
 @deployment.command(short_help='Restart a deployment for a project.')
 @click.argument('deployment')
 @click.option('--wait', is_flag=True, help='Wait for the deployment to complete initialization before exiting.')
+@click.option('--stop-on-error', is_flag=True, help='Stop the deployment if it fails on the first attempt. Implies --wait.')
 @click.option('--open', is_flag=True, help='Open a browser upon initialization. Implies --wait.')
 @click.option('--frame', is_flag=True, help='Include the AE banner when opening.')
 @format_options()
 @login_options()
 @click.pass_context
-def restart(ctx, deployment, wait, open, frame):
+def restart(ctx, deployment, wait, stop_on_error, open, frame):
     '''Restart a deployment for a project.
 
        The DEPLOYMENT identifier need not be fully specified, and may even include
        wildcards. But it must match exactly one project.
     '''
     result = cluster_call('deployment_restart', ident=deployment,
-                          wait=wait or open,
+                          wait=wait or open, stop_on_error=stop_on_error,
                           prefix='Restarting deployment {ident}...',
                           postfix='restarted.')
     if open:

--- a/ae5_tools/cli/commands/project.py
+++ b/ae5_tools/cli/commands/project.py
@@ -218,12 +218,13 @@ def upload(filename, name, tag, no_wait):
 @click.option('--public', is_flag=True, help='Make the deployment public.')
 @click.option('--private', is_flag=True, help='Make the deployment private (the default).')
 @click.option('--wait', is_flag=True, help='Wait for the deployment to complete initialization before exiting.')
+@click.option('--stop-on-error', is_flag=True, help='Stop the deployment if it fails on the first attempt. Implies --wait.')
 @click.option('--open', is_flag=True, help='Open a browser upon initialization. Implies --wait.')
 @click.option('--frame', is_flag=True, help='Include the AE banner when opening.')
 @format_options()
 @login_options()
 @click.pass_context
-def deploy(ctx, project, name, endpoint, command, resource_profile, public, private, wait, open, frame):
+def deploy(ctx, project, name, endpoint, command, resource_profile, public, private, wait, stop_on_error, open, frame):
     '''Start a deployment for a project.
 
        The PROJECT identifier need not be fully specified, and may even include
@@ -241,7 +242,8 @@ def deploy(ctx, project, name, endpoint, command, resource_profile, public, priv
     from .deployment import start as deployment_start
     ctx.invoke(deployment_start, project=project, name=name, endpoint=endpoint,
                resource_profile=resource_profile, command=command,
-               public=public, private=private, wait=wait, open=open, frame=frame)
+               public=public, private=private, wait=wait,
+               stop_on_error=stop_on_error, open=open, frame=frame)
 
 
 @project.command()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -215,6 +215,18 @@ def test_deploy_logs(user_session, api_deployment):
     assert 'App Proxy is fully operational!' in logs['proxy'], logs['proxy']
 
 
+def test_deploy_broken(user_session):
+    uname = user_session.username
+    dname = 'testbroken'
+    with pytest.raises(RuntimeError):
+        user_session.deployment_start(f'{uname}/testproj3', name=dname,
+                                      command='broken', public=False,
+                                      stop_on_error=True)
+    drecs = [r for r in user_session.deployment_list()
+             if r['owner'] == uname and r['name'] == dname]
+    assert len(drecs) == 0, drecs
+
+
 def test_login_time(admin_session, user_session):
     # The current session should already be authenticated
     now = datetime.utcnow()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -218,10 +218,11 @@ def test_deploy_logs(user_session, api_deployment):
 def test_deploy_broken(user_session):
     uname = user_session.username
     dname = 'testbroken'
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError) as excinfo:
         user_session.deployment_start(f'{uname}/testproj3', name=dname,
                                       command='broken', public=False,
                                       stop_on_error=True)
+    assert str('Error completing deployment start: App failed to run') in str(excinfo.value)
     drecs = [r for r in user_session.deployment_list()
              if r['owner'] == uname and r['name'] == dname]
     assert len(drecs) == 0, drecs

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,7 @@ import glob
 from datetime import datetime
 from collections import namedtuple
 from ae5_tools.api import AEUnexpectedResponseError
+from subprocess import CalledProcessError
 
 from .utils import _cmd
 
@@ -231,7 +232,7 @@ def test_deploy_broken(user_session):
     uname = user_session.username
     dname = 'testdeploy'
     ename = 'testbroken'
-    with pytest.raises(RuntimeError):
+    with pytest.raises(CalledProcessError):
         _cmd(f'project deploy {uname}/testproj3 --name {dname} --endpoint {ename} --command broken --private --stop-on-error', table=False)
     drecs = [r for r in _cmd('deployment list')
              if r['owner'] == uname and r['name'] == dname]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -181,7 +181,7 @@ def cli_deployment(user_session):
     uname = user_session.username
     dname = 'testdeploy'
     ename = 'testendpoint'
-    _cmd(f'project deploy {uname}/testproj3 --name testdeploy --endpoint testendpoint --command default --private --wait', table=False)
+    _cmd(f'project deploy {uname}/testproj3 --name {dname} --endpoint {ename} --command default --private --wait', table=False)
     drecs = [r for r in _cmd('deployment list')
              if r['owner'] == uname and r['name'] == dname]
     assert len(drecs) == 1, drecs
@@ -225,6 +225,17 @@ def test_deploy_logs(user_session, cli_deployment):
     assert 'The project is ready to run commands.' in app_logs
     assert app_prefix in event_logs, event_logs
     assert 'App Proxy is fully operational!' in proxy_logs, proxy_logs
+
+
+def test_deploy_broken(user_session):
+    uname = user_session.username
+    dname = 'testdeploy'
+    ename = 'testbroken'
+    with pytest.raises(RuntimeError):
+        _cmd(f'project deploy {uname}/testproj3 --name {dname} --endpoint {ename} --command broken --private --stop-on-error', table=False)
+    drecs = [r for r in _cmd('deployment list')
+             if r['owner'] == uname and r['name'] == dname]
+    assert len(drecs) == 0, drecs
 
 
 def test_login_time(admin_session, user_session):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -230,10 +230,9 @@ def test_deploy_logs(user_session, cli_deployment):
 
 def test_deploy_broken(user_session):
     uname = user_session.username
-    dname = 'testdeploy'
-    ename = 'testbroken'
+    dname = 'testbroken'
     with pytest.raises(CalledProcessError):
-        _cmd(f'project deploy {uname}/testproj3 --name {dname} --endpoint {ename} --command broken --private --stop-on-error', table=False)
+        _cmd(f'project deploy {uname}/testproj3 --name {dname} --command broken --private --stop-on-error', table=False)
     drecs = [r for r in _cmd('deployment list')
              if r['owner'] == uname and r['name'] == dname]
     assert len(drecs) == 0, drecs


### PR DESCRIPTION
Fixes #65.

If a deployment is broken—due to an error in anaconda-project prepare, or the user code itself—Kubernetes cheerfully attempts to re-deploy the container indefinitely. This adds a `--stop-on-error` option to the deployment start/restart commands so that a deployment that errors out on the first attempt is stopped and not re-run.