### PR TITLE
Multi-line headers

### DIFF
--- a/ae5_tools/api.py
+++ b/ae5_tools/api.py
@@ -28,11 +28,11 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 KEYCLOAK_PAGE_MAX = os.environ.get('KEYCLOAK_PAGE_MAX', 1000)
 
 
-_P_COLUMNS = [            'name', 'owner', 'editor',   'resource_profile',                                    'id',               'created', 'updated', 'project_create_status', 'url']  # noqa: E241, E201
-_R_COLUMNS = [            'name', 'owner', 'commands',                                                        'id', 'project_id', 'created', 'updated',                          'url']  # noqa: E241, E201
-_S_COLUMNS = [            'name', 'owner',             'resource_profile',                           'state', 'id', 'project_id', 'created', 'updated',                          'url']  # noqa: E241, E201
-_D_COLUMNS = ['endpoint', 'name', 'owner', 'command',  'resource_profile', 'project_name', 'public', 'state', 'id', 'project_id', 'created', 'updated',                          'url']  # noqa: E241, E201
-_J_COLUMNS = [            'name', 'owner', 'command',  'resource_profile', 'project_name',           'state', 'id', 'project_id', 'created', 'updated',                          'url']  # noqa: E241, E201
+_P_COLUMNS = [            'name', 'owner', 'editor',              'resource_profile',                           'id', 'created', 'updated', 'project_create_status',               'url']  # noqa: E241, E201
+_R_COLUMNS = [            'name', 'owner', 'commands',                                                          'id', 'created', 'updated',                          'project_id', 'url']  # noqa: E241, E201
+_S_COLUMNS = [            'name', 'owner', 'changes', 'modified', 'resource_profile',                           'id', 'created', 'updated', 'state',                 'project_id', 'url']  # noqa: E241, E201
+_D_COLUMNS = ['endpoint', 'name', 'owner', 'command',             'resource_profile', 'project_name', 'public', 'id', 'created', 'updated', 'state',                 'project_id', 'url']  # noqa: E241, E201
+_J_COLUMNS = [            'name', 'owner', 'command',             'resource_profile', 'project_name',           'id', 'created', 'updated', 'state',                 'project_id', 'url']  # noqa: E241, E201
 _C_COLUMNS = ['id',  'permission', 'type', 'first name', 'last name', 'email']  # noqa: E241, E201
 _U_COLUMNS = ['username', 'firstName', 'lastName', 'lastLogin', 'email', 'id']
 _T_COLUMNS = ['name', 'id', 'description', 'is_template', 'is_default', 'download_url', 'owner', 'created', 'updated']
@@ -179,12 +179,15 @@ class AESessionBase(object):
         else:
             raise ValueError('Not a tabular data format')
         clist = list(columns or ())
-        cset = set(clist)
+        csrc = set()
+        cdst = set(clist)
         for rec in response:
-            clist.extend(c for c in rec if c not in cset)
-            cset.update(rec)
+            clist.extend(c for c in rec if c not in cdst)
+            cdst.update(rec)
+            csrc.update(rec)
+        clist = [c for c in clist if c in csrc]
         for col, dtype in _DTYPES.items():
-            if col in cset:
+            if col in cdst:
                 if dtype == 'datetime':
                     for rec in response:
                         if rec.get(col):
@@ -791,29 +794,27 @@ class AEUserSession(AESessionBase):
 
     def _join_changes(self, record):
         for rec in ([record] if isinstance(record, dict) else record):
-            changes = self.session_changes(rec['id'], format='json')
+            try:
+                changes = self.session_changes(rec['id'], format='json')
+            except AEException:
+                continue
             rec['changes'] = ', '.join(r['path'] for r in changes)
             rec['modified'] = max((r['modified'] or rec['updated'] for r in changes), default='')
-        return _S_COLUMNS[:2] + ['changes', 'modified'] + _S_COLUMNS[2:]
 
     def session_list(self, internal=False, changes=False, format=None):
         response = self._get('sessions')
         # We need _join_projects even in internal mode to replace
         # the internal session name with the project name
         self._join_projects(response, 'session')
-        headers = _S_COLUMNS
         if not internal and changes:
-            headers = self._join_changes(response)
-        return self._format_response(response, format, columns=headers)
+            self._join_changes(response)
+        return self._format_response(response, format, columns=_S_COLUMNS)
 
     def session_info(self, ident, internal=False, changes=False, format=None, quiet=False):
         id, record = self._id('sessions', ident, quiet=quiet)
-        if record:
-            self._join_projects(record, 'session')
-        headers = _S_COLUMNS
         if not internal and changes:
-            headers = self._join_changes(record)
-        return self._format_response(record, format, columns=headers)
+            self._join_changes(record)
+        return self._format_response(record, format, columns=_S_COLUMNS)
 
     def session_changes(self, ident, master=False, format=None):
         id, _ = self._id('sessions', ident)

--- a/ae5_tools/cli/format.py
+++ b/ae5_tools/cli/format.py
@@ -270,22 +270,30 @@ def print_table(records, columns, header=True, width=0):
         owidth, nwidth = nwidth, nwidth + wid + 2
         if nwidth >= width:
             break
-    if header:
-        lines.insert(0, [('-' * wid, wid) for wid in widths])
-        nhead = max(len(col) for col in columns2)
-        columns = [[''] * (nhead - len(col)) + col for col in columns2]
-        for ndx in range(1, nhead + 1):
-            header = []
-            for col, wid in zip(columns, widths):
-                tcol = col[-ndx]
-                if ndx == 1 or not header or header[-1][0] != tcol:
-                    header.append((tcol, wid))
-                else:
-                    header[-1] = (tcol, wid + 2 + header[-1][1])
-            header = [(' ' * (max((0, w - len(c))) // 2) + c, w) for c, w in header]
-            lines.insert(0, header)
     lines = ['  '.join(v[:w] + ' ' * max((0, w - len(v))) for v, w in line)
              for line in lines]
+    if header:
+        lines.insert(0, '  '.join('-' * wid for wid in widths))
+        nhead = max(len(col) for col in columns2)
+        for ndx in range(1, nhead + 1):
+            header = []
+            for col, wid in zip(columns2, widths):
+                if ndx > len(col):
+                    header.append(('', wid, False))
+                    continue
+                label = col[-ndx]
+                if ndx == 1 or not header or header[-1][0] != label:
+                    header.append((label, wid, False))
+                else:
+                    header[-1] = (label, wid + 2 + header[-1][1], True)
+            for ndx, (label, wid, multi) in enumerate(header):
+                nw = max(0, wid - len(label)) // 2
+                if multi:
+                    nd = min(3, nw - 1)
+                    label = '-' * nd + ' ' + label + ' ' + '-' * nd
+                    nw -= nd + 1
+                header[ndx] = ' ' * nw + label + ' ' * (wid - len(label) - nw)
+            lines.insert(0, '  '.join(header))
     if nwidth > width:
         n = min(3, max(0, width - owidth - 2))
         dots, dashes, spaces = '.' * n, '-' * n, ' ' * n

--- a/ae5_tools/cli/format.py
+++ b/ae5_tools/cli/format.py
@@ -216,13 +216,13 @@ def print_csv(records, columns, header):
 # Column header splitting methodology:
 # - Forward slashes delimit category levels, so we always split those
 # - We split along underscores when necessary, but we keep the underscore
-#   with its previous chunk so the user knows it is part of column label.
+#   so the user knows it is part of column label.
 # - We split along spaces as well (but we currently have no examples of this)
 
 
 def header_width(col):
     return max(max(len(chunk2.rstrip())
-                   for chunk2 in re.findall('[^_ ]*_? *', chunk1))
+                   for chunk2 in chunk1.split('_'))
                for chunk1 in col.split('/'))
 
 
@@ -230,7 +230,7 @@ def split_header(col, wid):
     result = []
     for chunk1 in col.split('/'):
         first = True
-        for chunk2 in re.findall(r'[^_ ]*_? *', chunk1):
+        for chunk2 in chunk1.partition('_'):
             if first or len(chunk2) + len(result[-1]) > wid:
                 result.append(chunk2)
             else:
@@ -260,7 +260,7 @@ def print_table(records, columns, header=True, width=0):
     columns2 = []
     for ndx in range(len(columns)):
         vals = [_str(rec[ndx]) for rec in records]
-        wid = max((len(v) for v in vals), default=0)
+        wid = max((1, max((len(v) for v in vals), default=0)))
         if header:
             wid = max((wid, header_width(columns[ndx])))
             columns2.append(split_header(columns[ndx], wid))


### PR DESCRIPTION
In preparation for the k8s-related improvements I have implemented multi-line headers. This is used already to wrap existing labels at the underscore `_` to reduce column size growth caused solely by a long header name; e.g., `resource_profile`. But this will also be used to handle hierarchical labels such as `usage/memory`, `usage/cpu`, `usage/gpu`.