### PR TITLE
Relax endpoint checks in the CLI; detect duplicate endpoints differently

### DIFF
--- a/ae5_tools/cli/commands/deployment.py
+++ b/ae5_tools/cli/commands/deployment.py
@@ -147,15 +147,6 @@ def start(ctx, project, name, endpoint, command, resource_profile, public, priva
         if not re.match(r'[A-Za-z0-9-]+', endpoint):
             click.ClickException(f'Invalid endpoint: {endpoint}')
         prec = cluster_call('project_info', project, collaborators=False, format='json')
-        for e in endpoints:
-            if e['id'] != endpoint:
-                continue
-            elif e['deployment_id']:
-                raise click.ClickException(f'Endpoint {endpoint} is already active')
-            elif e['owner'] and e['owner'] != prec['owner']:
-                raise click.ClickException(f'Endpoint {endpoint} is claimed by user {e["owner"]}')
-            elif e['project_id'] and e['project_id'] != prec['id']:
-                raise click.ClickException(f'Endpoint {endpoint} is claimed by project {e["project_name"]}')
     name_s = f' {name}' if name else ''
     endpoint_s = f' at endpoint {endpoint}' if endpoint else ''
     response = cluster_call('deployment_start', ident=project, id_class='project',

--- a/ae5_tools/cli/login.py
+++ b/ae5_tools/cli/login.py
@@ -192,6 +192,8 @@ def cluster_call(method, *args, **kwargs):
         c = cluster(admin=admin)
         result = getattr(c, method)(*args, **kwargs)
     except AEException as e:
+        if postfix or prefix:
+            click.echo('', nl=True, err=True)
         raise click.ClickException(str(e))
 
     # Finish out the standardized CLI output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -236,6 +236,17 @@ def test_deploy_logs(user_session, cli_deployment):
     assert 'App Proxy is fully operational!' in proxy_logs, proxy_logs
 
 
+def test_deploy_duplicate(user_session, cli_deployment):
+    uname = user_session.username
+    dname = 'testdeploy2'
+    ename = 'testendpoint'
+    with pytest.raises(CalledProcessError):
+        _cmd(f'project deploy {uname}/testproj3 --name {dname} --endpoint {ename} --command default --private --wait', table=False)
+    drecs = [r for r in _cmd('deployment list')
+             if r['owner'] == uname and r['name'] == dname]
+    assert len(drecs) == 0, drecs
+
+
 def test_deploy_broken(user_session):
     uname = user_session.username
     dname = 'testbroken'


### PR DESCRIPTION
Fixes #78. We remove the endpoint checks in the CLI tool completely, and replace it with an endpoint test in the API itself, which only verifies that the endpoint is not currently active.