### PR TITLE
WIP: Initialize ~/.ae5 directory to prevent problems.  Closes #92 and #86

### DIFF
--- a/ae5_tools/cli/main.py
+++ b/ae5_tools/cli/main.py
@@ -13,6 +13,16 @@ import click
 import click_repl
 from prompt_toolkit.history import FileHistory
 
+
+from ..exceptions import AE5FatalError, AE5ConfigError
+# Import first as it has side-effects that can fail
+# this ensures the ~/.ae5 dir exists - and can raise AE5FatalError
+try:
+    from ..config import config  # noqa
+except AE5ConfigError as e:
+    click.echo(f'Configuration Error: {e}')
+    sys.exit(-1)
+
 from .commands.project import project
 from .commands.account import account
 from .commands.session import session
@@ -37,8 +47,11 @@ from .utils import stash_defaults, global_options
 @global_options
 @click.pass_context
 def cli(ctx):
-    if ctx.invoked_subcommand is None:
-        ctx.invoke(repl)
+    try:
+        if ctx.invoked_subcommand is None:
+            ctx.invoke(repl)
+    except AE5FatalError as e:
+        click.echo(f'Fatal Error: {e}')
 
 
 @cli.command(hidden=True)

--- a/ae5_tools/config.py
+++ b/ae5_tools/config.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 
 from http.cookiejar import LWPCookieJar
@@ -6,28 +7,31 @@ from datetime import datetime
 from dateutil import tz
 
 
+from .exceptions import AE5ConfigError
+
+
 RC_DIR = "~/.ae5"
 CONFIG_FILE = "config.py"
-
-
-class AE5_Fatal_Error(Exception):
-    pass
+logger = logging.getLogger(__name__)
 
 
 class ConfigManager:
     def __init__(self):
         self._path = os.path.expanduser(os.getenv('AE5_TOOLS_CONFIG_DIR') or RC_DIR)
+        self.init_path()
         self._data = {}
         self.load()
 
     def init_path(self):
+        """Ensure the config directory exists"""
+        logger.debug(f'Creating directory: {self._path}')
         try:
             os.makedirs(self._path, mode=0o700, exist_ok=True)
         except OSError as e:
             # todo:  log e.errno - 13 means bad permissions
             #        17: file exists
             msg = f"Cannot create directory {self._path}. Please check directory permissions."
-            raise AE5_Fatal_Error(msg)
+            raise AE5ConfigError(msg)
 
     @property
     def config_path(self):
@@ -117,4 +121,3 @@ class ConfigManager:
 
 
 config = ConfigManager()
-config.init_path()

--- a/ae5_tools/exceptions.py
+++ b/ae5_tools/exceptions.py
@@ -1,0 +1,7 @@
+
+class AE5FatalError(Exception):
+    pass
+
+
+class AE5ConfigError(AE5FatalError):
+    pass

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,102 @@
+import os
+import sys
+import importlib
+
+
+import pytest
+
+
+from ae5_tools import exceptions
+
+@pytest.fixture
+def random_home_dir(tmpdir, monkeypatch):
+    """Create a random home directory for testing ~/.ae5"""
+    monkeypatch.setenv("HOME", str(tmpdir))
+    return tmpdir
+
+
+@pytest.fixture
+def bad_home_dir(random_home_dir):
+    """Create a home directory with bad permissions"""
+    os.chmod(random_home_dir, 0o000)
+    yield random_home_dir
+    os.chmod(random_home_dir, 0o777)
+
+
+@pytest.fixture
+def clear_config_import():
+    """
+    Need to force reload config module after setting $HOME to test ~/.ae5 directory creation
+    """
+    def clear_import():
+        try:
+            del sys.modules['config']
+            print("Cleared config import")
+        except KeyError:
+            pass
+
+    clear_import()
+    yield
+
+    # Reset it back to unloaded
+    clear_import()
+
+
+def test_ae5_dir_creation(random_home_dir, clear_config_import):
+    """Assume ~/.ae5 already was created, make a fake homedir and test dir creation"""
+    print(f'home directory: {random_home_dir}')
+    from ae5_tools import config
+    # I'm not sure why i need to force-reload this after clearing it
+    importlib.reload(config)
+
+    config_dir = os.path.expanduser(config.RC_DIR)
+
+    assert type(config.config) is config.ConfigManager
+    assert os.path.exists(config_dir)
+    assert config_dir == os.path.join(config.config._path)
+
+
+def test_ae5_dir_bad_perms(bad_home_dir, clear_config_import):
+    """Bad permissions on home directory"""
+    print(f'bad home directory: {bad_home_dir}')
+    os.chmod(bad_home_dir, 0o000)
+    with pytest.raises(exceptions.AE5ConfigError):
+        from ae5_tools import config
+
+        # I'm not sure why i need to force-reload this after clearing it
+        importlib.reload(config)
+
+
+def test_ae5_dir_file_exists(random_home_dir, clear_config_import):
+    """A file named ~/.ae5 is blocking directory creation"""
+    print(f'home directory: {random_home_dir}')
+
+    # hard coded here because config is not loaded yet
+    config_dir = os.path.join(random_home_dir, ".ae5")
+    with open(config_dir, 'w'):
+        pass
+
+    with pytest.raises(exceptions.AE5ConfigError):
+        from ae5_tools import config
+        importlib.reload(config)
+
+
+def test_ae5_dir_env_variable(clear_config_import, tmpdir, monkeypatch):
+    """Test env variable: AE5_TOOLS_CONFIG_DIR"""
+    monkeypatch.setenv("AE5_TOOLS_CONFIG_DIR", str(tmpdir))
+
+    from ae5_tools import config
+    importlib.reload(config)
+
+    config_dir = tmpdir
+    assert config_dir == config.config._path
+    assert os.path.exists(config_dir)
+
+
+#
+# todo:  need to cover:]
+#    - load
+#    - save
+#    - list
+#    - resolve
+#


### PR DESCRIPTION
This creates ~/.ae5 or ENV(AE5_TOOLS_CONFIG_DIR) at runtime or import time if using it as an API.

1.  If it cannot create the RC config directory, it will raise an AE5ConfigException.
2. AE5ConfigException is caught in the main.py.  Slightly ugly, I force an unneeded `import config` to trigger the directory creation in a controlled way, to handle the exception cleanly.
3. A try-except block catching AE5FatalException is now wrapping the CLI commands.  This is a way to exit gracefully on an expected failure.  

Caveat to API usage:  It will create a directory ~/.ae5 or $AE5_TOOLS_CONFIG_DIR and raise an exception.AE5ConfigException if it cannot.  The code importing must be able to handle that.

## Tests

1. Because it creates the directory on import, any tests that `import config`, can fail if ~/.ae5 cannot be created/used. This should be an acceptable risk, as refactoring this to be safe makes a lot of complicated code (it's much easier to not require every consumer of config to first run an initialize function).

2. I added a number of tests to verify $AE5_TOOLS_CONFIG_DIR works correctly, and a few different filesystem level failures will be caught gracefully.  