### PR TITLE
Add  --k8s option to runs; prune completed runs from pod list

### DIFF
--- a/ae5_tools/api.py
+++ b/ae5_tools/api.py
@@ -454,7 +454,7 @@ class AEUserSession(AESessionBase):
         self._filename = os.path.join(config._path, 'cookies', f'{username}@{hostname}')
         super(AEUserSession, self).__init__(hostname, username, password=password,
                                             prefix='api/v2', persist=persist)
-        self._k8s_endpoint = k8s_endpoint or 'k8s'
+        self._k8s_endpoint = k8s_endpoint or os.environ.get('AE5_K8S_ENDPOINT') or 'k8s'
         self._k8s_client = None
 
     def _k8s(self, method, *args, **kwargs):

--- a/ae5_tools/api.py
+++ b/ae5_tools/api.py
@@ -943,8 +943,10 @@ class AEUserSession(AESessionBase):
                         rec['changes'] = ''
                 rec['node'] = rec2['node']
                 rec['_k8s'] = rec2
+            if not rlist2:
+                rlist2 = EmptyRecordList(rlist[0]['_record_type'], rlist[0])
             rlist = rlist2
-        elif hasattr(rlist, '_columns'):
+        if not rlist and hasattr(rlist, '_columns'):
             rlist._columns.extend(('phase', 'since', 'rst', 'usage/mem', 'usage/cpu', 'usage/gpu'))
             if changes:
                 rlist._columns.extend(('changes', 'modified'))

--- a/ae5_tools/api.py
+++ b/ae5_tools/api.py
@@ -459,13 +459,15 @@ class AEUserSession(AESessionBase):
 
     def _k8s(self, method, *args, **kwargs):
         quiet = kwargs.pop('quiet', False)
-        if self._k8s_endpoint:
+        if self._k8s_client is None and self._k8s_endpoint is not None:
             if self._k8s_endpoint.startswith('ssh:'):
-                self._k8s_client = AE5K8SLocalClient(self.hostname, self._k8s_endpoint.split(':', 1)[1])
+                username = self._k8s_endpoint[4:]
+                self._k8s_client = AE5K8SLocalClient(self.hostname, username)
             else:
                 self._k8s_client = AE5K8SRemoteClient(self, self._k8s_endpoint)
             estr = self._k8s_client.error()
             if estr:
+                del self._k8s_client
                 self._k8s_endpoint = self._k8s_client = None
                 msg = ['Error establishing k8s connection:']
                 msg.extend('  ' + x for x in estr.splitlines())

--- a/ae5_tools/api.py
+++ b/ae5_tools/api.py
@@ -918,8 +918,12 @@ class AEUserSession(AESessionBase):
         is_single = isinstance(record, dict)
         rlist = [record] if is_single else record
         if rlist:
+            rlist2 = []
             record2 = self._k8s('pod_info', [r['id'] for r in rlist])
             for rec, rec2 in zip(rlist, record2):
+                if not rec2:
+                    continue
+                rlist2.append(rec)
                 rec['phase'] = rec2['phase']
                 rec['since'] = rec2['since']
                 rec['rst'] = rec2['restarts']
@@ -937,11 +941,13 @@ class AEUserSession(AESessionBase):
                         rec['changes'] = ''
                 rec['node'] = rec2['node']
                 rec['_k8s'] = rec2
+            rlist = rlist2
         elif hasattr(rlist, '_columns'):
             rlist._columns.extend(('phase', 'since', 'rst', 'usage/mem', 'usage/cpu', 'usage/gpu'))
             if changes:
                 rlist._columns.extend(('changes', 'modified'))
             rlist._columns.extend(('node', '_k8s'))
+        return record if is_single else rlist
 
     def _pre_session(self, records):
         # The "name" value in an internal AE5 session record is nothing
@@ -959,7 +965,7 @@ class AEUserSession(AESessionBase):
 
     def _post_session(self, records, k8s=False):
         if k8s:
-            self._join_k8s(records, True)
+            return self._join_k8s(records, changes=True)
         return records
 
     def session_list(self, filter=None, k8s=False, format=None):
@@ -1040,9 +1046,9 @@ class AEUserSession(AESessionBase):
 
     def _post_deployment(self, records, collaborators=False, k8s=False):
         if collaborators:
-             self._join_collaborators('deployments', records)
+            self._join_collaborators('deployments', records)
         if k8s:
-            self._join_k8s(records, False)
+            return self._join_k8s(records, changes=False)
         return records
 
     def deployment_list(self, filter=None, collaborators=False, k8s=False, format=None):
@@ -1232,6 +1238,15 @@ class AEUserSession(AESessionBase):
             response = response['token']
         return self._format_response(response, format=format)
 
+    def _pre_job(self, records):
+        precs = {x['id']: x for x in self._get_records('projects')}
+        for rec in records:
+            pid = 'a0-' + rec['project_url'].rsplit('/', 1)[-1]
+            prec = precs.get(pid, {})
+            rec['project_id'] = pid
+            rec['_project'] = prec
+        return records
+
     def job_list(self, filter=None, format=None):
         response = self._get_records('jobs', filter=filter)
         return self._format_response(response, format=format)
@@ -1342,12 +1357,17 @@ class AEUserSession(AESessionBase):
             jrec = self._ident_record('job', id)
         return self._format_response(jrec, format=format)
 
-    def run_list(self, filter=None, format=None):
-        response = self._get_records('runs', filter=filter)
+    # runs need the same preprocessing as jobs,
+    # and the same postprocessing as sessions
+    _pre_run = _pre_job
+    _post_run = _post_session
+
+    def run_list(self, k8s=False, filter=None, format=None):
+        response = self._get_records('runs', k8s=k8s, filter=filter)
         return self._format_response(response, format=format)
 
-    def run_info(self, ident, format=None, quiet=False):
-        response = self._ident_record('run', ident, quiet=quiet)
+    def run_info(self, ident, k8s=False, format=None, quiet=False):
+        response = self._ident_record('run', ident, k8s=k8s, quiet=quiet)
         return self._format_response(response, format=format)
 
     def run_log(self, ident, format=None):
@@ -1373,8 +1393,7 @@ class AEUserSession(AESessionBase):
         return records
 
     def _post_pod(self, records):
-        self._join_k8s(records, True)
-        return records
+        return self._join_k8s(records, changes=True)
 
     def pod_list(self, filter=None, format=None):
         records = (self.session_list(filter=filter) + 

--- a/ae5_tools/cli/commands/run.py
+++ b/ae5_tools/cli/commands/run.py
@@ -14,6 +14,7 @@ def run():
 
 @run.command()
 @ident_filter('run')
+@click.option('--k8s', is_flag=True, help='Include Kubernetes-derived columns (requires additional API calls).')
 @global_options
 def list(**kwargs):
     '''List all available run records.
@@ -28,6 +29,7 @@ def list(**kwargs):
 
 @run.command()
 @ident_filter('run', required=True)
+@click.option('--k8s', is_flag=True, help='Include Kubernetes-derived columns (requires additional API calls).')
 @global_options
 def info(**kwargs):
     '''Retrieve information about a single run.

--- a/ae5_tools/k8s/client.py
+++ b/ae5_tools/k8s/client.py
@@ -16,8 +16,7 @@ class AE5K8SClient(object):
         return self._api('get', 'nodes').json()
 
     def pod_info(self, ids):
-        path = f'pods?' + '&'.join('id=' + x for x in ids)
-        result = self._api('get', path).json()
+        result = self._api('post', 'pods', json=ids).json()
         result = [result.get(x) for x in ids]
         return result
 

--- a/ae5_tools/k8s/client.py
+++ b/ae5_tools/k8s/client.py
@@ -29,8 +29,11 @@ class AE5K8SLocalClient(object):
     def node_info(self):
         return self._run(self.xfrm.node_info())
 
-    def pod_info(self, ids):
-        return self._run(self.xfrm.pod_info(ids))
+    def pod_info(self, ids, quiet=True):
+        result = self._run(self.xfrm.pod_info(ids, return_exceptions=quiet))
+        if quiet:
+            result = [None if isinstance(v, Exception) else v for v in result]
+        return result
 
     def pod_log(self, id, container=None, follow=False):
         self._run(self.xfrm.pod_log(id, container, follow))
@@ -62,10 +65,12 @@ class AE5K8SRemoteClient(object):
     def node_info(self):
         return self._get('nodes', format='json')
 
-    def pod_info(self, ids):
+    def pod_info(self, ids, quiet=True):
         path = f'pods?' + '&'.join('id=' + x for x in ids)
+        if quiet:
+            path += '&quiet=1'
         result = self._get(path, format='json')
-        result = [result[x] for x in ids]
+        result = [result.get(x) for x in ids]
         return result
 
     def pod_log(self, id, container=None, follow=False):

--- a/ae5_tools/k8s/client.py
+++ b/ae5_tools/k8s/client.py
@@ -1,75 +1,23 @@
-import asyncio
-import requests
 import sys
-import io
+import requests
+import subprocess
 
-from .transformer import AE5K8STransformer
-from .ssh import tunneled_k8s_url
+from .ssh import launch_background, tunneled_k8s_url
 
 
-class AE5K8SLocalClient(object):
-    def __init__(self, hostname, username):
-        self._error = self.xfrm = None
-        try:
-            url = tunneled_k8s_url(hostname, username)
-            self.xfrm = AE5K8STransformer(url)
-        except RuntimeError as exc:
-            self._error = str(exc)
-
-    def _run(self, request):
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(request)
-
+class AE5K8SClient(object):
     def error(self):
         return self._error
 
     def status(self):
-        return 'Alive and kicking'
+        return self._api('get', '').text
 
     def node_info(self):
-        return self._run(self.xfrm.node_info())
+        return self._api('get', 'nodes').json()
 
-    def pod_info(self, ids, quiet=True):
-        result = self._run(self.xfrm.pod_info(ids, return_exceptions=quiet))
-        if quiet:
-            result = [None if isinstance(v, Exception) else v for v in result]
-        return result
-
-    def pod_log(self, id, container=None, follow=False):
-        self._run(self.xfrm.pod_log(id, container, follow))
-
-
-class AE5K8SRemoteClient(object):
-    def __init__(self, session, subdomain):
-        self._error = None
-        try: 
-            session._head('/_errors/404.html', subdomain=subdomain, format='response')
-            response = session._get('/', subdomain=subdomain, format='text')
-            if response == 'Alive and kicking':
-                self._session = session
-                self._subdomain = subdomain
-            else:
-                self._error = f'Unexpected response at endpoint {subdomain}'
-        except RuntimeError:
-            self._error = f'No deployment found at endpoint {subdomain}'
-
-    def _get(self, path, **kwargs):
-        return self._session._get(path, subdomain=self._subdomain, **kwargs)
-
-    def error(self):
-        return self._error
-
-    def status(self):
-        return self._get('/', format='text')
-
-    def node_info(self):
-        return self._get('nodes', format='json')
-
-    def pod_info(self, ids, quiet=True):
+    def pod_info(self, ids):
         path = f'pods?' + '&'.join('id=' + x for x in ids)
-        if quiet:
-            path += '&quiet=1'
-        result = self._get(path, format='json')
+        result = self._api('get', path).json()
         result = [result.get(x) for x in ids]
         return result
 
@@ -78,7 +26,54 @@ class AE5K8SRemoteClient(object):
         path = f'pod/{id}/log?follow={follow_s}'
         if container is not None:
             path = f'{path}&container={container}'
-        response = self._get(path, format='response', stream=True)
+        response = self._api('get', path, stream=True)
         for chunk in response.iter_content():
             if chunk:
                 stream.write(chunk.decode('utf-8', errors='replace'))
+
+
+class AE5K8SLocalClient(AE5K8SClient):
+    def __init__(self, hostname, username):
+        self._ssh = self._server = None
+        try:
+            self._ssh, ssh_url = tunneled_k8s_url(hostname, username)
+        except RuntimeError as exc:
+            self._error = str(exc)
+            return
+        cmd = ['python', '-u', '-m', 'ae5_tools.k8s.server', ssh_url]
+        try:
+            self._server = launch_background(cmd, '======== Running on', 'start server')
+            self._error = None
+        except RuntimeError as exc:
+            self._error = str(exc)
+
+    def __del__(self):
+        if sys.meta_path is not None:
+            if self._server is not None and self._server.returncode is None:
+                self._server.terminate()
+                self._server.communicate()
+            if self._ssh is not None and self._ssh.returncode is None:
+                self._ssh.terminate()
+                self._ssh.communicate()
+
+    def _api(self, method, path, **kwargs):
+        return getattr(requests, method)(f'http://localhost:8086/{path}', **kwargs)
+
+
+class AE5K8SRemoteClient(AE5K8SClient):
+    def __init__(self, session, subdomain):
+        self._session = session
+        self._subdomain = subdomain
+        try:
+            session._head('/_errors/404.html', format='response')
+            response = session._get('', subdomain=subdomain, format='text')
+            if response == 'Alive and kicking':
+                self._error = None
+            else:
+                self._error = f'Unexpected response at endpoint {subdomain}'
+        except RuntimeError as exc:
+            self._error = f'No deployment found at endpoint {subdomain}'
+
+    def _api(self, method, path, **kwargs):
+        return self._session._api(method, path, subdomain=self._subdomain,
+                                  format='response', **kwargs)

--- a/ae5_tools/k8s/ssh.py
+++ b/ae5_tools/k8s/ssh.py
@@ -8,8 +8,9 @@ import sys
 
 def register_cleanup(proc):
     def cleanup():
-        proc.terminate()
-        proc.communicate()
+        if proc.returncode is None:
+            proc.terminate()
+            proc.communicate()
     atexit.register(cleanup)
 
 
@@ -23,6 +24,22 @@ def raise_error(stdout, stderr, errcode, cmd, msg):
         msg.append('  ---- STDERR ---')
         msg.extend('  ' + x for x in stderr.splitlines())
     raise RuntimeError('\n'.join(msg))
+
+
+def launch_background(cmd, waitfor, what, retries=1):
+    for attempt in range(retries):
+        proc = subprocess.Popen(cmd, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE, universal_newlines=True)
+        stdout = ''
+        for line in proc.stdout:
+            stdout += line
+            if line.startswith(waitfor):
+                register_cleanup(proc)
+                return proc
+        stderr = proc.stderr.read()
+        proc.terminate()
+        proc.communicate()
+    raise_error(stdout, stderr, proc.returncode, cmd, f'Could not {what}')
 
 
 def find_remote_port(hostname, username):
@@ -44,41 +61,23 @@ def find_remote_port(hostname, username):
     raise_error(stdout, stderr, errcode, cmd,
                 'Could not determine available remote port')
 
-
 def find_local_port():
     # https://stackoverflow.com/questions/2838244/get-open-tcp-port-in-python/2838309#2838309
     s = socket.socket()
     s.bind(("", 0))
     local_port = s.getsockname()[1]
+    if local_port == 8086:
+        # Don't use 8086 so we can be sure it's available when running this server locally
+        local_port = find_local_port()
     s.close()
     return local_port
 
 
 def tunneled_k8s_url(hostname, username):
-    """Race condition on finding a port and binging to it, so retry as a hack"""
-    retry = 3
-    captured_exception = None
-    for i in range(retry):
-        try:
-            return _tunneled_k8s_url(hostname, username)
-        except RuntimeError as e:
-            captured_exception = e
-    raise captured_exception
-
-
-def _tunneled_k8s_url(hostname, username):
     remote_port = find_remote_port(hostname, username)
     local_port = find_local_port()
     cmd = ['ssh', '-o', 'StrictHostKeyChecking=no', '-t', '-t', '-L',
            f'{local_port}:localhost:{remote_port}', f'{username}@{hostname}',
            'kubectl', 'proxy', '--disable-filter', f'--port={remote_port}']
-    proc = subprocess.Popen(cmd, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE, universal_newlines=True)
-    stdout = ''
-    for line in proc.stdout:
-        stdout += line
-        if line.startswith('Starting to serve'):
-            register_cleanup(proc)
-            return f'http://localhost:{local_port}'
-    raise_error(stdout, proc.stderr.read(), proc.returncode, cmd,
-                'Could not establish k8s proxy')
+    proc = launch_background(cmd, 'Starting to serve', 'establish k8s proxy', retries=3)
+    return proc, f'http://localhost:{local_port}'

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -61,8 +61,7 @@ def test_user_session(monkeypatch, capsys):
     assert f'Password for {username}@{hostname}' in captured.err
     assert f'Invalid username or password; please try again.' in captured.err
     assert f'Must supply a password' in captured.err
-    assert c._k8s('status') == 'Alive and kicking'
-    c._k8s_client, c._k8s_endpoint = None, 'ssh:fakeuser'
+    true_endpoint, c._k8s_endpoint = c._k8s_endpoint, 'ssh:fakeuser'
     with pytest.raises(AEException) as excinfo:
         c._k8s('status')
     assert 'Error establishing k8s connection' in str(excinfo.value)
@@ -73,6 +72,8 @@ def test_user_session(monkeypatch, capsys):
     with pytest.raises(AEException) as excinfo:
         c._k8s('status')
     assert 'No k8s connection available' in str(excinfo.value)
+    c._k8s_endpoint = true_endpoint
+    assert c._k8s('status') == 'Alive and kicking'
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
Requires a few changes:

- Endow `run_list`, `run_info` with the --k8s option
- Add `project_id` to runs and jobs
- Allow the k8s queries to fail silently for runs that are already completed