### PR TITLE
Fix ae5 project image and run on port 8086

### DIFF
--- a/ae5_tools/Dockerfile.dist
+++ b/ae5_tools/Dockerfile.dist
@@ -17,7 +17,7 @@ RUN yum install -y bzip2 && \
     bash miniconda.sh -b -p /opt/conda && \
     cp condarc /opt/conda/.condarc && \
     conda config --set auto_update_conda False --set notify_outdated_conda false --system && \
-    conda install anaconda-project --yes && \
+    conda install anaconda-project=0.8.4 --yes && \
     conda clean --all --yes && \
     rm -f condarc miniconda.sh && \
     useradd anaconda
@@ -29,6 +29,5 @@ RUN tar xfz project.tar.gz --strip-components=1 && \
     anaconda-project --verbose prepare && \
     rm -rf ~/.conda project.tar.gz
 
-# This runs the specified deployment command, which could (for
-# instance launch a REST API or web app.
-CMD anaconda-project run
+# The CMD layer will be added by AE5-tools to execute the default
+# or desired command over port 8086

--- a/ae5_tools/api.py
+++ b/ae5_tools/api.py
@@ -804,7 +804,7 @@ class AEUserSession(AESessionBase):
         if need_filename:
             return filename
 
-    def project_image(self, ident, command=None, condarc_path=None, dockerfile_path=None, debug=False, format=None):
+    def project_image(self, ident, command=None, condarc=None, dockerfile=None, debug=False, format=None):
         '''Build docker image'''
         rrec = self._revision(ident, keep_latest=True)
         prec, rev = rrec['_project'], rrec['id']
@@ -812,8 +812,8 @@ class AEUserSession(AESessionBase):
         owner = prec['owner'].replace('@','_at_')
         tag = f'{owner}/{name}:{rev}'
 
-        dockerfile = get_dockerfile(dockerfile_path)
-        condarc = get_condarc(condarc_path)
+        dockerfile_contents = get_dockerfile(dockerfile)
+        condarc_contents = get_condarc(condarc)
 
         if command:
             commands = [c['id'] for c in rrec['commands']]
@@ -822,7 +822,8 @@ class AEUserSession(AESessionBase):
                 print('Remove the --command option to build the container anyway.')
                 return
             if command in commands:
-                dockerfile = re.sub('(CMD anaconda-project run)(.*?)$', f'\g<1> {command}', dockerfile)
+                dockerfile_contents = re.sub('(CMD anaconda-project run)(.*?)$', f'\g<1> {command}',
+                                             dockerfile_contents)
             else:
                 print(f'The command {command} is not one of the configured commands.')
                 print('Available commands are:')
@@ -836,10 +837,10 @@ class AEUserSession(AESessionBase):
 
         with TemporaryDirectory() as tempdir:
             with open(os.path.join(tempdir, 'Dockerfile'), 'w') as f:
-                f.write(dockerfile)
+                f.write(dockerfile_contents)
 
             with open(os.path.join(tempdir, 'condarc'), 'w') as f:
-                f.write(condarc)
+                f.write(condarc_contents)
 
             self.project_download(ident, filename=os.path.join(tempdir, 'project.tar.gz'))
             


### PR DESCRIPTION
* this fixes a bug in `ae5 project image` where it was not calling the function with the correct arguments.
* will always add a CMD layer to the dockerimage to run either the chosen command or the default command
* The CMD layer always adds `--anaconda-project-port 8086`