### PR TITLE
Fix file upload on Windows

### DIFF
--- a/ae5_tools/api.py
+++ b/ae5_tools/api.py
@@ -897,7 +897,11 @@ class AEUserSession(AESessionBase):
         if not name:
             if type(project_archive) == bytes:
                 raise RuntimeError('Project name must be supplied for binary input')
-            name = basename(abspath(project_archive)).split('.', 1)[0]
+            name = basename(abspath(project_archive))
+            for suffix in  ('.tar.gz', '.tar.bz2', '.tar.gz', '.zip', '.tgz', '.tbz', '.tbz2', '.tz2', '.txz'):
+                if name.endswith(suffix):
+                    name = name[:-len(suffix)]
+                    break
         try:
             f = None
             if type(project_archive) == bytes:
@@ -911,12 +915,13 @@ class AEUserSession(AESessionBase):
             else:
                 f = io.BytesIO()
                 create_tar_archive(project_archive, 'project', f)
-                f.seek(0)
+            f.seek(0)
             data = {'name': name}
             if tag:
                 data['tag'] = tag
             response = self._post_record('projects/upload', record_type='project',
-                                         api_kwargs={'files': {'project_file': f}, 'data': data})
+                                         api_kwargs={'files': {b'project_file': f},
+                                         'data': data})
         finally:
             if f is not None:
                 f.close()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,7 +12,7 @@ import uuid
 from datetime import datetime
 
 from ae5_tools.api import AEUserSession, AEUnexpectedResponseError, AEException
-from .utils import _get_vars
+from .utils import _get_vars, _compare_tarfiles
 
 
 class AttrDict(dict):
@@ -230,6 +230,7 @@ def test_project_upload(user_session, downloaded_project):
     fname2 = user_session.project_download(f'test_upload1:{rev}')
     assert fname2 == f'test_upload1-{rev}.tar.gz'
     assert os.path.exists(fname2)
+    _compare_tarfiles(fname, fname2)
     if rev == '0.0.1':
         pytest.xfail("5.4.1 revision issue")
     assert rev == '1.2.3'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from collections import namedtuple
 from ae5_tools.api import AEUnexpectedResponseError
 
-from .utils import _cmd, CMDException
+from .utils import _cmd, _compare_tarfiles, CMDException
 
 
 @pytest.fixture(scope='module')
@@ -146,6 +146,7 @@ def test_project_upload(downloaded_project):
     fname2 = _cmd(f'project download test_upload1:{rev}', table=False).strip()
     assert fname2 == f'test_upload1-{rev}.tar.gz'
     assert os.path.exists(fname2)
+    _compare_tarfiles(fname, fname2)
     if rev == '0.0.1':
         pytest.xfail("5.4.1 revision issue")
     assert rev == '1.2.3'


### PR DESCRIPTION
A customer discovered failures in the project upload functionality on Windows. It turns out the fix is exactly a single character: the `project_file` dictionary key passed to the Requests library must in fact be a bytestring. I suspect that this is an encoding issue.

The PR is significantly longer than this however because I built a test to verify that the contents of the project are precisely preserved after an upload/download round trip. Plus I fixed an issue where a file with periods in the actual project name frustrated a simpler default name selection.