### PR TITLE
Remove codecov from ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
         mv conda-bld $CONDA/
         source $CONDA/etc/profile.d/conda.sh
         conda config --prepend channels ae5-admin
-        conda create -y -n ptest local::ae5-tools python=3.6 pytest pytest-cov codecov pandas
+        conda create -y -n ptest local::ae5-tools python=3.6 pytest pandas
     - name: Test the package
       shell: bash
       env:


### PR DESCRIPTION
Looks like we've stopped using codecov, but let's remove it anyway, because of
https://about.codecov.io/security-update/