### PR TITLE
Fix deployment restart version pinning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
         mv conda-bld $CONDA/
         source $CONDA/etc/profile.d/conda.sh
         conda config --prepend channels ae5-admin
-        conda create -y -n ptest local::ae5-tools python=3.6 pytest pytest-cov codecov pandas
+        conda create -y -n ptest local::ae5-tools python=3.6 pytest pandas
     - name: Test the package
       shell: bash
       env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: true
       max-parallel: 1
       matrix:
-        os: [windows-latest,ubuntu-latest]
+        os: [ubuntu-latest]
     steps:
     - name: Retrieve the source code
       uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: true
       max-parallel: 1
       matrix:
-        os: [ubuntu-latest]
+        os: [windows-latest,ubuntu-latest]
     steps:
     - name: Retrieve the source code
       uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
         mv conda-bld $CONDA/
         source $CONDA/etc/profile.d/conda.sh
         conda config --prepend channels ae5-admin
-        conda create -y -n ptest local::ae5-tools python=3.6 pytest pandas
+        conda create -y -n ptest local::ae5-tools python=3.6 pytest-cov pandas
     - name: Test the package
       shell: bash
       env:

--- a/ae5_tools/api.py
+++ b/ae5_tools/api.py
@@ -674,8 +674,17 @@ class AEUserSession(AESessionBase):
 
     def _pre_sample(self, records):
         for record in records:
-            record['is_template'] = 'is_default' in record
-            record.setdefault('is_default', False)
+            if record.get('is_default'):
+                record['is_default'] = False
+        first_template = None
+        found_default = False
+        for record in records:
+            record['is_default'] = bool(not found_default and record.get('is_template') and record.get('is_default'))
+            record.setdefault('is_template', False)
+            first_template = first_template or record
+            found_default = found_default or record['is_default']
+        if not found_default and first_template:
+            first_template['is_default'] = True
         return records
 
     def sample_list(self, filter=None, format=None):

--- a/ae5_tools/api.py
+++ b/ae5_tools/api.py
@@ -1233,7 +1233,7 @@ class AEUserSession(AESessionBase):
         else:
             endpoint = None
         self.deployment_stop(drec)
-        return self.deployment_start(drec['project_id'],
+        return self.deployment_start('{}:{}'.format(drec['project_id'], drec['revision']),
                                      endpoint=endpoint, command=drec['command'],
                                      resource_profile=drec['resource_profile'],
                                      public=drec['public'],

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -35,7 +35,6 @@ test:
     - python-dateutil=2.7
     - pytest
     - pytest-cov
-    - codecov
     - pandas
   commands:
     - py.test --cov=ae5_tools -v tests

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -458,7 +458,8 @@ def test_deploy_token(user_session, api_deployment):
     prec, drec = api_deployment
     token = user_session.deployment_token(drec)
     resp = requests.get(f'https://{drec["endpoint"]}.' + user_session.hostname,
-                        headers={'Authorization': f'Bearer {token}'})
+                        headers={'Authorization': f'Bearer {token}'},
+                        verify=False)
     assert resp.status_code == 200
     assert resp.text.strip() == 'Hello Anaconda Enterprise!', resp.text
     with pytest.raises(AEException) as excinfo:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -344,7 +344,8 @@ def test_deploy_token(user_session, cli_deployment):
     prec, drec = cli_deployment
     token = _cmd(f'deployment token {drec["id"]}', table=False).strip()
     resp = requests.get(f'https://{drec["endpoint"]}.' + user_session.hostname,
-                        headers={'Authorization': f'Bearer {token}'})
+                        headers={'Authorization': f'Bearer {token}'},
+                        verify=False)
     assert resp.status_code == 200
     assert resp.text.strip() == 'Hello Anaconda Enterprise!', resp.text
 


### PR DESCRIPTION
`deployment restart` commands end up changing the deployment to using the "latest" version instead of a fixed pinned version.

Also we need to get rid of codecov