### PR TITLE
Add `failed` to state list to avoid endless loop while waiting for job to finish or fail

### DIFF
--- a/ae5_tools/api.py
+++ b/ae5_tools/api.py
@@ -1382,6 +1382,7 @@ class AEUserSession(AESessionBase):
             run = self._get_records(f'jobs/{jid}/runs')[-1]
             if wait:
                 rid = run['id']
+                # wait for run to complete one way or another.
                 while run['state'] not in ('completed', 'error', 'failed'):
                     time.sleep(5)
                     run = self._get(f'runs/{rid}')

--- a/ae5_tools/api.py
+++ b/ae5_tools/api.py
@@ -1382,7 +1382,7 @@ class AEUserSession(AESessionBase):
             run = self._get_records(f'jobs/{jid}/runs')[-1]
             if wait:
                 rid = run['id']
-                while run['state'] not in ('completed', 'error'):
+                while run['state'] not in ('completed', 'error', 'failed'):
                     time.sleep(5)
                     run = self._get(f'runs/{rid}')
                 if cleanup:


### PR DESCRIPTION
Jobs that fail in Anaconda Enterprise can return a `state` of "failed". When this happens, the job gets stuck in an endless loop. Simply adding "failed" the the list of states will exit the loop addresses this issue.