### PR TITLE
Added user "realm roles" to `user list`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ test_vars.sh
 .vscode
 .pytest_cache
 
+.DS_Store
+envs/
+anaconda-project-local.yml

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2019 Anaconda, Inc.
+Copyright 2023 Anaconda, Inc.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/anaconda-project.yml
+++ b/anaconda-project.yml
@@ -1,12 +1,58 @@
 name: ae5-tools
+description: Command-line manipulation of Anaconda Enterprise 5.
+
 commands:
+  #
+  # Run Time Commands
+  #
+
   default:
+    env_spec: default
     unix: python -m ae5_tools.k8s.server
+
+  #
+  # Development Time Commands
+  #
+
+  test:
+    env_spec: development
+    unix: anaconda-project run clean && anaconda-project run test:unit && anaconda-project run test:system
+
+  test:unit:
+    env_spec: development
+    unix: py.test --cov=ae5_tools -v tests/unit  --cov-append --cov-report=xml
+
+  test:system:
+    env_spec: development
+    unix: py.test --cov=ae5_tools -v tests/system  --cov-append --cov-report=xml
+
 channels:
   - defaults
-packages:
-  - requests
-  - python-dateutil
-  - aiohttp
+  - conda-forge
+
+platforms:
+  - linux-64
+  - osx-64
+  - osx-arm64
+  - win-64
+
 env_specs:
-  default: {}
+  default:
+    description: Default environment spec for k8s server
+    packages:
+      - python>=3.6
+      - python-dateutil
+      - requests
+      - aiohttp
+  development:
+    description: Development environment spec for running commands
+    packages:
+      - python>=3.6
+      - python-dateutil
+      - click>7
+      - click-repl
+      - requests
+      - aiohttp
+      - pytest
+      - pytest-cov
+      - pandas

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -31,8 +31,12 @@ test:
   source_files:
     - tests
   requires:
-    - python=3.6
-    - python-dateutil=2.7
+    - python>=3.6
+    - python-dateutil
+    - click>7
+    - click-repl
+    - requests
+    - aiohttp
     - pytest
     - pytest-cov
     - pandas

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setuptools.setup(
     name="ae5-tools",
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
-    url="https://github.com/mcg1969/ae5-tools",
+    url="https://github.com/Anaconda-Platform/ae5-tools",
     author="Anaconda, Inc.",
     description="A pluggable framework for AE5 administration CLI tools.",
     long_description="A pluggable framework for AE5 administration CLI tools.",

--- a/tests/system/ae5_tools/test_api.py
+++ b/tests/system/ae5_tools/test_api.py
@@ -1,0 +1,36 @@
+from typing import Dict, List
+
+#####################################################
+# Test Cases For user_list
+#####################################################
+
+
+def test_user_list_has_realm_roles(admin_session):
+    # Test Case - User list contains realm roles
+
+    # Execute the test
+    user_list: List = admin_session.user_list()
+
+    # The live system will have more than 0 users
+    assert len(user_list) > 0
+
+    # Look for the admin account
+    account: Dict = [user for user in user_list if user["username"] == "anaconda-enterprise"][0]
+
+    # Ensure the new property is present
+    assert "realm_roles" in account
+
+    # Ensure the property has roles which would be present on the account
+    assert len(account["realm_roles"]) > 0
+
+    # Ensure the account has the expected roles assigned.
+    expected_roles: List[str] = [
+        "offline_access",
+        "ae-deployer",
+        "uma_authorization",
+        "ae-uploader",
+        "ae-admin",
+        "ae-creator",
+    ]
+    for role in expected_roles:
+        assert role in account["realm_roles"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -488,3 +488,10 @@ def test_login_time(admin_session, user_session):
     ltm1 = datetime.strptime(urec['lastLogin'], "%Y-%m-%d %H:%M:%S.%f")
     assert ltm1 < now
     # No more testing here, because we want to preserve the existing sessions
+
+def test_realm_roles(admin_session):
+    _cmd('project', 'list')
+    user_list = _cmd('user', 'list')
+
+    # Validate realms roles are present on the user
+    assert "realm_roles" in user_list[0]

--- a/tests/unit/ae5_tools/test_api_user_list.py
+++ b/tests/unit/ae5_tools/test_api_user_list.py
@@ -1,0 +1,164 @@
+import datetime
+import os
+import sys
+import uuid
+from typing import Dict
+from unittest.mock import MagicMock
+
+import pytest
+
+from ae5_tools.api import AEAdminSession
+
+
+@pytest.fixture(scope="function")
+def get_token_fixture():
+    return {
+        "access_token": str(uuid.uuid4()),
+        "refresh_token": str(uuid.uuid4()),
+    }
+
+
+@pytest.fixture(scope="function")
+def admin_session(get_token_fixture):
+    admin_session = AEAdminSession(
+        hostname="MOCK-HOSTNAME", username="MOCK-AE-USERNAME", password="MOCK-AE-USER-PASSWORD"
+    )
+    admin_session._load = MagicMock()
+    admin_session._sdata = get_token_fixture
+    return admin_session
+
+
+@pytest.fixture(scope="function")
+def generate_raw_user_fixture() -> Dict:
+    mock_user_id: str = str(uuid.uuid4())
+    return {
+        "id": mock_user_id,
+        "name": "MOCK-USERNAME",
+        "details": {},
+        "userId": mock_user_id,
+        "time": datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+    }
+
+
+#####################################################
+# Test Cases For _get_user_realm_roles
+#####################################################
+
+
+def test_get_user_realm_roles(admin_session):
+    test_cases = [
+        # Test Case 1 - We get expected results
+        {
+            "user_uuid": str(uuid.uuid4()),
+            "realm_roles": [
+                {"name": "ae-admin", "id": str(uuid.uuid4())},
+                {"name": "ae-reader", "id": str(uuid.uuid4())},
+            ],
+            "expected_results": ["ae-admin", "ae-reader"],
+        },
+        # Test Case 2 - No roles
+        {"user_uuid": str(uuid.uuid4()), "realm_roles": [], "expected_results": []},
+    ]
+
+    for test_case in test_cases:
+        # Set up test
+        admin_session._get_paginated = MagicMock(return_value=test_case["realm_roles"])
+
+        # Execute the test
+        result = admin_session._get_user_realm_roles(user_uuid=test_case["user_uuid"])
+
+        # Review results
+        assert result == test_case["expected_results"]
+
+        mock = admin_session._get_paginated
+        mock.assert_called_once_with(f"users/{test_case['user_uuid']}/role-mappings/realm", limit=sys.maxsize, first=0)
+
+
+#####################################################
+# Test Cases For _merge_users_with_realm_roles
+#####################################################
+
+
+def test_merge_users_with_realm_roles(admin_session, generate_raw_user_fixture):
+    test_cases = [
+        # Test Case 1 - Empty Roles
+        {
+            "realm_roles": [],
+        },
+        # Test Case 2 - Matching Roles For A Single User
+        {
+            "realm_roles": ["ae-admin", "ae-reader"],
+        },
+    ]
+
+    for test_case in test_cases:
+        test_case["users"] = [generate_raw_user_fixture]
+        test_case["expected_results"] = [{**test_case["users"][0], "realm_roles": test_case["realm_roles"]}]
+
+        # Set up test
+        admin_session._get_user_realm_roles = MagicMock(return_value=test_case["realm_roles"])
+
+        # Execute the test
+        result = admin_session._merge_users_with_realm_roles(users=test_case["users"])
+
+        # Review results
+        assert result == test_case["expected_results"]
+
+        mock = admin_session._get_user_realm_roles
+        mock.assert_called_once_with(user_uuid=test_case["users"][0]["id"])
+
+
+#####################################################
+# Test Cases For user_list
+#####################################################
+
+
+def test_user_list_with_no_users(admin_session):
+    test_cases = [
+        # Test Case 1 - No Users
+        {"users": [], "mapped_users": [], "expected_results": []},
+    ]
+
+    for test_case in test_cases:
+        # Set up test
+        admin_session._get_paginated = MagicMock(return_value=test_case["users"])
+        admin_session._merge_users_with_realm_roles = MagicMock(return_value=test_case["mapped_users"])
+
+        # Execute the test
+        result = admin_session.user_list()
+
+        # Review results
+        assert result == test_case["expected_results"]
+
+
+def test_user_list(admin_session, generate_raw_user_fixture):
+    test_cases = [
+        # Test Case 1 - User does not have any roles
+        {"realm_roles": []},
+        # Test 2 - User belongs to a role
+        {
+            "realm_roles": ["ae-admin"],
+        },
+    ]
+
+    for test_case in test_cases:
+        test_case["users"] = [generate_raw_user_fixture]
+        test_case["mapped_users"] = [{**test_case["users"][0], "realm_roles": test_case["realm_roles"]}]
+        test_case["expected_results"] = [
+            {
+                **test_case["users"][0],
+                "realm_roles": test_case["realm_roles"],
+                "_record_type": "user",
+                "lastLogin": test_case["users"][0]["time"],
+            }
+        ]
+
+        # Set up test
+        admin_session._get_paginated = MagicMock(return_value=test_case["users"])
+        admin_session._merge_users_with_realm_roles = MagicMock(return_value=test_case["mapped_users"])
+
+        # Execute the test
+        result = admin_session.user_list()
+
+        # Review results
+        assert result == test_case["expected_results"]


### PR DESCRIPTION
# What?
* Added realm roles a user is assigned to when using the `user list` command.

# Why?
* We've had a client request for additional user level control.  Specifically the ability to expose and operate on a user's roles.

# How?

* It doesn't look that we currently have any method to access this data.  I was able to find the related KeyCloak API documentation for this however:

From https://www.keycloak.org/docs-api/12.0/rest-api/#_userrepresentation

>        Get realm-level role mappings:
>        GET /{realm}/groups/{id}/role-mappings/realm

* I can see two ways to approach this.  Let me know if there are better/other solutions given performance considerations.

**Option 1 (Current implementation)**
* Get user roles on a per-user basis.  I have to request additional user data on a per-user level. So `n` calls for `n` users.

**Option 2 (Alternative)**
* Get all roles, and correlate user assignment with the user list.
* I would need to see if I can get a role list, and then request each role's assignments (if possible).  Then correlate this to the user list.  I think we could get this down to `1 + n` group calls plus some local processing.  
     * However, I've been unsuccessful in making these requests to AE5.  I'm not sure if this is due to the url mutations performed by the REST layer, or if we have some other constraints on exposed routes of KeyCloak.

If there are a lot of users optional 1 will be slower.  If there are a lot of roles then option 2 would be slower.  There might also be different endpoints which provide all the user or role level information in a single call.  I'm new to KeyCloak so this could easily be the case. :)


# How was this tested?
* Unit tests added
* System tests added

# Possible Discussion Points
* KeyCloak User<->Role Mapping Thoughts
* Column name.  It's currently `realm_roles`.  It looks like internally there might also be other role types as well as groups.  If/when we expose these I didn't want to have overlap.  Please let me know if you have any suggestions on naming.

# Notes
* I have a simple dynamic network ae5 mock which is usable for the integration tests I wrote.  I am however also running into issues getting this to work as expected when run through the GitHub Action.  I've pulled this out for now and will introduce it later once I have the issues ironed out.
* There is opportunity to split the test suites up (unit/integration/system) but did not want to introduce a large amount of change in this PR.  I'll do this separately.