### PR TITLE
`dev` label on conda package build always resolves true

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,5 +36,5 @@ jobs:
         ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
       run: |
         source $CONDA/bin/activate
-        git tag describe --exact-match --tags HEAD || export LABEL="--label dev"
+        git describe --tags --exact-match --tags HEAD || export LABEL="--label dev"
         anaconda --verbose --token $ANACONDA_TOKEN upload --user ae5-admin $LABEL $CONDA/conda-bld/noarch/ae5-tools-*.tar.bz2 --force

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,10 +1,5 @@
-name: Build and test
+name: Pull Request and Dev Publish
 on:
-  push:
-    branches:
-      - master
-    tags:
-      - '*'
   pull_request:
     branches:
       - master
@@ -30,11 +25,9 @@ jobs:
         rm -f $CONDA/conda-bld/noarch/ae5-tools-*.tar.bz2
         conda install -y conda-build conda-verify anaconda-client
         conda build conda-recipe
-    - name: Upload to anaconda.org
-      if: github.event_name == 'push'
+    - name: Upload to anaconda.org (Dev Build)
       env:
         ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
       run: |
         source $CONDA/bin/activate
-        git describe --tags --exact-match --tags HEAD || export LABEL="--label dev"
-        anaconda --verbose --token $ANACONDA_TOKEN upload --user ae5-admin $LABEL $CONDA/conda-bld/noarch/ae5-tools-*.tar.bz2 --force
+        anaconda --verbose --token $ANACONDA_TOKEN upload --user ae5-admin --label dev $CONDA/conda-bld/noarch/ae5-tools-*.tar.bz2 --force

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,35 @@
+name: Merge to master and publish
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+jobs:
+  package:
+    runs-on: self-hosted
+    steps:
+    - name: Retrieve the source code
+      uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3
+      with:
+        fetch-depth: 0
+    - name: Build the package
+      env:
+        AE5_HOSTNAME: aip.anaconda.com
+        AE5_USERNAME: tooltest
+        AE5_PASSWORD: ${{ secrets.AE5_PASSWORD }}
+        AE5_ADMIN_USERNAME: admin
+        AE5_ADMIN_PASSWORD: ${{ secrets.AE5_ADMIN_PASSWORD }}
+        AE5_K8S_ENDPOINT: ssh:centos
+        AE5_K8S_PORT: 23456
+      run: |
+        source $CONDA/etc/profile.d/conda.sh
+        rm -f $CONDA/conda-bld/noarch/ae5-tools-*.tar.bz2
+        conda install -y conda-build conda-verify anaconda-client
+        conda build conda-recipe
+    - name: Upload to anaconda.org
+      env:
+        ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+      run: |
+        source $CONDA/bin/activate
+        anaconda --verbose --token $ANACONDA_TOKEN upload --user ae5-admin $CONDA/conda-bld/noarch/ae5-tools-*.tar.bz2 --force


### PR DESCRIPTION
This command is failing within the github actions:

<img width="1107" alt="Screenshot 2023-03-13 at 11 56 29 AM" src="https://user-images.githubusercontent.com/5835886/224802166-47145000-3494-4abf-92a0-cb5b9d52970b.png">

It appears that the intent is to label the build as `dev` if a tag is not present.  As written this always resolved as true.

I've explicitly split pull-request and merge time workflows up to aid in read-ability and reduce complexity.

Pull Requests to Master
--------------
Publish a package to the `dev` channel.

<img width="1013" alt="Screenshot 2023-03-13 at 12 41 05 PM" src="https://user-images.githubusercontent.com/5835886/224814823-cd6fe3fb-fb22-4f77-a947-12d26dcd2028.png">



Merge (Push) to Master
--------------
Publish a package to main channel.
