### PR TITLE
Enhancement - Explicitly Ensure Deployment Stopped Before Starting During Restart

### DIFF
--- a/ae5_tools/api.py
+++ b/ae5_tools/api.py
@@ -1444,7 +1444,26 @@ class AEUserSession(AESessionBase):
                 endpoint = None
         else:
             endpoint = None
+
+        # Get deployment Id
+        id = self._ident_record("deployment", ident)["id"]
+
+        # Begin the restart.
         self.deployment_stop(drec)
+
+        # Ensure the deployment has been stopped.
+        stopping: bool = True
+        time.sleep(2)
+        while stopping:
+            try:
+                self.deployment_info(ident=id)
+            except Exception as error:
+                if str(error).startswith("No deployments found matching"):
+                    stopping = False
+                else:
+                    time.sleep(2)
+
+        # Complete the restart
         return self.deployment_start(
             "{}:{}".format(drec["project_id"], drec["revision"]),
             endpoint=endpoint,

--- a/ae5_tools/api.py
+++ b/ae5_tools/api.py
@@ -1445,9 +1445,6 @@ class AEUserSession(AESessionBase):
         else:
             endpoint = None
 
-        # Get deployment Id
-        id = self._ident_record("deployment", ident)["id"]
-
         # Begin the restart.
         self.deployment_stop(drec)
 
@@ -1456,7 +1453,7 @@ class AEUserSession(AESessionBase):
         time.sleep(2)
         while stopping:
             try:
-                self.deployment_info(ident=id)
+                self.deployment_info(ident=drec["id"])
             except Exception as error:
                 if str(error).startswith("No deployments found matching"):
                     stopping = False


### PR DESCRIPTION
During a deployment restart we need to ensure that the deployment was stopped prior to attempting to restart it.  This change enforces a check that the deployment no longer exists during this action.