### PR TITLE
Revert "chore(deps): update actions/checkout action to v4"

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: self-hosted
     steps:
     - name: Retrieve the source code
-      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+      uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3
       with:
         fetch-depth: 0
     - name: Linting

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: self-hosted
     steps:
     - name: Retrieve the source code
-      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+      uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3
       with:
         fetch-depth: 0
     - name: Build the package


### PR DESCRIPTION
Reverts Anaconda-Platform/ae5-tools#173

This version is currently broken for self-hosted runners: https://github.com/actions/checkout/issues/1487