### PR TITLE
use a sortable date string format for filtering purposes

### DIFF
--- a/ae5_tools/cli/format.py
+++ b/ae5_tools/cli/format.py
@@ -227,7 +227,7 @@ def _str(x, isodate=False):
     elif isinstance(x, datetime):
         if isodate:
             return x.isoformat()
-        return x.strftime("%m-%d-%Y %H:%M:%S")
+        return x.strftime("%Y-%m-%d %H:%M:%S")
     else:
         return str(x)
 

--- a/ae5_tools/filter.py
+++ b/ae5_tools/filter.py
@@ -9,7 +9,7 @@ def _str(x, isodate=False):
     elif isinstance(x, datetime):
         if isodate:
             return x.isoformat()
-        return x.strftime("%m-%d-%Y %H:%M:%S")
+        return x.strftime("%Y-%m-%d %H:%M:%S")
     else:
         return str(x)
 


### PR DESCRIPTION
This modifies the string formatting for date so that less-than/greater-than filtering works properly.

Sorting was already working because the sorting was performed on the underlying datetime object.